### PR TITLE
ci(codeql): unblock CodeQL by skipping SSG and providing safe env defaults

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,16 @@ jobs:
       env:
         # Skip type checking during build for CodeQL
         SKIP_TYPE_CHECK: true
+        # Avoid SSG data fetching during CodeQL builds
+        NEXT_SKIP_BUILD_STATIC_GENERATION: true
+        # Disable Next telemetry for CI
+        NEXT_TELEMETRY_DISABLED: 1
+        # Provide safe defaults to satisfy env validation
+        NEXT_PUBLIC_SUPABASE_URL: https://example.com
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-anon-key
+        SUPABASE_SERVICE_ROLE_KEY: dummy-service-role
+        # Optional envs to reduce warnings during build
+        NEXT_PUBLIC_APP_URL: http://localhost:3000
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- Set NEXT_SKIP_BUILD_STATIC_GENERATION to avoid SSG hitting API during CodeQL\n- Provide safe NEXT_PUBLIC_SUPABASE_URL/ANON_KEY and SUPABASE_SERVICE_ROLE_KEY\n- Disable telemetry in CI\n\nThis should resolve prior failures: build error 'Invalid environment variables' and page data collection error for /api/admin/analytics during CodeQL runs. Once merged, CodeQL should produce analyzable results.