### PR TITLE
ci: add workflow to set Supabase access token hook

### DIFF
--- a/.github/workflows/set-auth-hook.yml
+++ b/.github/workflows/set-auth-hook.yml
@@ -1,0 +1,75 @@
+name: Set Supabase Access Token Hook
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_ref:
+        description: "Supabase project ref (optional; derived if omitted)"
+        required: false
+      hook_uri:
+        description: "Hook URI (default: pg-functions://supabase_auth_admin/public/custom_access_token_hook)"
+        required: false
+
+jobs:
+  set-hook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute project ref
+        id: ref
+        shell: bash
+        env:
+          IN_REF: ${{ github.event.inputs.project_ref }}
+          DB_URL: ${{ secrets.DATABASE_URL || secrets.PRODUCTION_DATABASE_URL || secrets.DB_URL }}
+          PUBLIC_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.REPO_NEXT_PUBLIC_SUPABASE_URL || secrets.PUBLIC_SUPABASE_URL }}
+        run: |
+          set -euo pipefail
+          REF="${IN_REF:-}"
+          if [ -z "$REF" ] && [ -n "${DB_URL:-}" ]; then
+            HOST=$(node -e "try{const u=new URL(process.env.DB_URL);console.log(u.hostname)}catch(e){process.exit(0)}")
+            if [[ "$HOST" == db.*.supabase.co ]]; then
+              REF=${HOST#db.}; REF=${REF%.supabase.co}
+            fi
+          fi
+          if [ -z "$REF" ] && [ -n "${PUBLIC_URL:-}" ]; then
+            HOST=$(node -e "try{const u=new URL(process.env.PUBLIC_URL);console.log(u.hostname)}catch(e){process.exit(0)}")
+            if [[ "$HOST" == *.supabase.co ]]; then
+              REF=${HOST%.supabase.co}
+            fi
+          fi
+          if [ -z "$REF" ]; then
+            echo "::error::Could not determine Supabase project ref. Provide input project_ref or set DATABASE_URL/NEXT_PUBLIC_SUPABASE_URL secrets." && exit 1
+          fi
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "Using project ref: $REF"
+
+      - name: Set access token hook via Management API
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN || secrets.SUPABASE_TOKEN || secrets.REPO_SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ steps.ref.outputs.ref }}
+          HOOK_URI: ${{ github.event.inputs.hook_uri }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+            echo "::error::SUPABASE_ACCESS_TOKEN secret is required (can be set at repo or environment level)." && exit 1
+          fi
+          URI="${HOOK_URI:-pg-functions://supabase_auth_admin/public/custom_access_token_hook}"
+          echo "Setting access token hook to: $URI"
+          API="https://api.supabase.com/v1/projects/${PROJECT_REF}/config/auth"
+          PAYLOAD=$(jq -n --arg uri "$URI" '{ hook: { access_token: { uri: $uri, enabled: true } } }')
+          curl -sS -X PATCH "$API" \
+            -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+
+      - name: Verify setting
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN || secrets.SUPABASE_TOKEN || secrets.REPO_SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          set -euo pipefail
+          API="https://api.supabase.com/v1/projects/${PROJECT_REF}/config/auth"
+          curl -sS "$API" -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" | jq '{hook: .hook}'
+


### PR DESCRIPTION
Adds a workflow that patches the Supabase project auth config via Management API to set the access token hook to pg-functions://supabase_auth_admin/public/custom_access_token_hook. It derives project ref from secrets or accepts it as input.