### PR TITLE
feat: add role-based dashboard experience

### DIFF
--- a/src/components/dashboard/client/client-dashboard.tsx
+++ b/src/components/dashboard/client/client-dashboard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ClientGoalProgress } from './goal-progress';
+import { ClientQuickActions } from './quick-actions';
+import { ClientRecentMessages } from './recent-messages';
+import { ClientUpcomingSessions } from './upcoming-sessions';
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface ClientDashboardProps {
+  userId: string;
+  locale: string;
+  translations: DashboardTranslations;
+  userName: string;
+}
+
+export function ClientDashboard({ userId, locale, translations, userName }: ClientDashboardProps) {
+  return (
+    <div className="space-y-6 lg:space-y-8">
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <ClientUpcomingSessions
+            userId={userId}
+            locale={locale}
+            translations={translations}
+          />
+          <ClientGoalProgress locale={locale} translations={translations} />
+        </div>
+        <div className="space-y-6">
+          <ClientQuickActions translations={translations} />
+          <ClientRecentMessages
+            locale={locale}
+            translations={translations}
+            userName={userName}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/client/goal-progress.tsx
+++ b/src/components/dashboard/client/goal-progress.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { CheckCircle2, Flag, TrendingUp } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from '@/i18n/routing';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface Goal {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  priority: 'high' | 'medium' | 'low';
+  status: 'not_started' | 'in_progress' | 'completed' | 'paused';
+  progress: number;
+  targetDate: string;
+  createdDate: string;
+}
+
+interface ProgressResponse {
+  goals: Goal[];
+  totalGoals: number;
+  completedGoals: number;
+  inProgressGoals: number;
+}
+
+interface GoalProgressProps {
+  locale: string;
+  translations: DashboardTranslations;
+}
+
+async function fetchGoalProgress(): Promise<ProgressResponse> {
+  const response = await fetch('/api/widgets/progress?limit=4', {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch goal progress');
+  }
+
+  const payload = await response.json();
+  return payload.data ?? { goals: [], totalGoals: 0, completedGoals: 0, inProgressGoals: 0 };
+}
+
+function resolvePriorityLabel(priority: Goal['priority'], t: DashboardTranslations['dashboard']) {
+  switch (priority) {
+    case 'high':
+      return t('clientSections.goalProgress.highPriority');
+    case 'medium':
+      return t('clientSections.goalProgress.mediumPriority');
+    case 'low':
+    default:
+      return t('clientSections.goalProgress.lowPriority');
+  }
+}
+
+export function ClientGoalProgress({ locale, translations }: GoalProgressProps) {
+  const { dashboard: t, common: commonT } = translations;
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: 'short',
+        day: 'numeric',
+      }),
+    [locale]
+  );
+
+  const { data, isLoading, isError, refetch } = useQuery<ProgressResponse>({
+    queryKey: ['client-goal-progress', locale],
+    queryFn: fetchGoalProgress,
+    staleTime: 60_000,
+  });
+
+  const goals = data?.goals ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <TrendingUp className="h-5 w-5" />
+          {t('clientSections.goalProgress.title')}
+        </CardTitle>
+        <CardDescription>{t('clientSections.goalProgress.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading && (
+          <div className="space-y-4">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={`goal-skeleton-${index}`} className="space-y-3 rounded-lg border p-4">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-2 w-full" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>{t('clientSections.goalProgress.error')}</p>
+            <Button onClick={() => refetch()} size="sm" variant="outline" className="mt-3">
+              {commonT('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && goals.length === 0 && (
+          <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            <Flag className="mx-auto mb-3 h-10 w-10 opacity-40" />
+            <p>{t('clientSections.goalProgress.empty')}</p>
+            <Button asChild variant="secondary" className="mt-4">
+              <Link href="/client/progress">
+                {t('clientSections.goalProgress.cta')}
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && goals.length > 0 && (
+          <div className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4 text-center">
+                <p className="text-sm text-muted-foreground">{t('clientSections.goalProgress.total')}</p>
+                <p className="text-2xl font-semibold text-foreground">{data?.totalGoals ?? 0}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4 text-center">
+                <p className="text-sm text-muted-foreground">{t('clientSections.goalProgress.completed')}</p>
+                <p className="text-2xl font-semibold text-foreground">{data?.completedGoals ?? 0}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4 text-center">
+                <p className="text-sm text-muted-foreground">{t('clientSections.goalProgress.inProgress')}</p>
+                <p className="text-2xl font-semibold text-foreground">{data?.inProgressGoals ?? 0}</p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {goals.map((goal) => (
+                <div key={goal.id} className="rounded-lg border border-border/60 bg-background p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-sm text-foreground">{goal.title}</p>
+                      <p className="text-xs text-muted-foreground">{goal.description}</p>
+                    </div>
+                    {goal.status === 'completed' && (
+                      <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-2.5 py-0.5 text-xs font-medium text-emerald-600">
+                        <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+                        {t('clientSections.goalProgress.completedLabel')}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{resolvePriorityLabel(goal.priority, t)}</span>
+                    <span>
+                      {t('clientSections.goalProgress.target', { date: dateFormatter.format(new Date(goal.targetDate)) })}
+                    </span>
+                  </div>
+                  <Progress value={Math.round(goal.progress)} className="mt-3 h-2" />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/client/quick-actions.tsx
+++ b/src/components/dashboard/client/quick-actions.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Calendar, FileText, MessageCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Link } from '@/i18n/routing';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface ClientQuickActionsProps {
+  translations: DashboardTranslations;
+}
+
+const clientActions = [
+  {
+    key: 'schedule-session',
+    icon: Calendar,
+    href: '/client/book',
+    labelKey: 'clientSections.quickActions.schedule',
+  },
+  {
+    key: 'view-files',
+    icon: FileText,
+    href: '/files',
+    labelKey: 'clientSections.quickActions.files',
+  },
+  {
+    key: 'contact-coach',
+    icon: MessageCircle,
+    href: '/messages',
+    labelKey: 'clientSections.quickActions.contact',
+  },
+] as const;
+
+export function ClientQuickActions({ translations }: ClientQuickActionsProps) {
+  const { dashboard: t } = translations;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Calendar className="h-5 w-5" />
+          {t('clientSections.quickActions.title')}
+        </CardTitle>
+        <CardDescription>{t('clientSections.quickActions.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {clientActions.map((action) => (
+          <Button key={action.key} asChild variant="outline" className="w-full justify-start">
+            <Link href={action.href}>
+              <action.icon className="mr-2 h-4 w-4" />
+              {t(action.labelKey)}
+            </Link>
+          </Button>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/client/recent-messages.tsx
+++ b/src/components/dashboard/client/recent-messages.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { ArrowRight, MessageSquare, UserCircle } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from '@/i18n/routing';
+import type { Conversation, Message, User } from '@/types';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface ClientRecentMessagesProps {
+  locale: string;
+  translations: DashboardTranslations;
+  userName: string;
+}
+
+interface MessagesResponse {
+  data?: Conversation[];
+}
+
+const MESSAGE_LIMIT = 4;
+
+function buildParticipantName(participants: User[]): string {
+  if (!participants || participants.length === 0) {
+    return '—';
+  }
+  const [firstParticipant] = participants;
+  const segments = [firstParticipant.firstName, firstParticipant.lastName].filter(Boolean);
+  return segments.length > 0 ? segments.join(' ') : firstParticipant.email;
+}
+
+function buildAvatarFallback(name: string) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function buildPreview(lastMessage?: Message): string {
+  if (!lastMessage) {
+    return '';
+  }
+  const preview = lastMessage.content || '';
+  return preview.length > 120 ? `${preview.slice(0, 117)}…` : preview;
+}
+
+async function fetchRecentMessages(): Promise<Conversation[]> {
+  const params = new URLSearchParams({ limit: String(MESSAGE_LIMIT) });
+  const response = await fetch(`/api/messages?${params.toString()}`, {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch messages');
+  }
+
+  const payload: MessagesResponse = await response.json();
+  return payload.data ?? [];
+}
+
+export function ClientRecentMessages({ locale, translations, userName }: ClientRecentMessagesProps) {
+  const { dashboard: t, common: commonT } = translations;
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+        month: 'short',
+        day: 'numeric',
+      }),
+    [locale]
+  );
+
+  const { data, isLoading, isError, refetch } = useQuery<Conversation[]>({
+    queryKey: ['client-recent-messages', userName],
+    queryFn: fetchRecentMessages,
+    staleTime: 30_000,
+  });
+
+  const messages = data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <MessageSquare className="h-5 w-5" />
+          {t('clientSections.recentMessages.title')}
+        </CardTitle>
+        <CardDescription>{t('clientSections.recentMessages.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading && (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={`message-skeleton-${index}`} className="flex items-start gap-3">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-full" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>{t('clientSections.recentMessages.error')}</p>
+            <Button onClick={() => refetch()} size="sm" variant="outline" className="mt-3">
+              {commonT('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && messages.length === 0 && (
+          <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            <UserCircle className="mx-auto mb-3 h-10 w-10 opacity-50" />
+            <p>{t('clientSections.recentMessages.empty')}</p>
+            <Button asChild className="mt-4" variant="secondary">
+              <Link href="/messages">
+                <ArrowRight className="mr-2 h-4 w-4" />
+                {t('clientSections.recentMessages.cta')}
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && messages.length > 0 && (
+          <div className="space-y-4">
+            {messages.map((conversation) => {
+              const participantName = buildParticipantName(conversation.participants || []);
+              const lastMessageTime = conversation.lastMessage?.createdAt
+                ? dateFormatter.format(new Date(conversation.lastMessage.createdAt))
+                : '';
+              const unreadCount = conversation.unreadCount ?? 0;
+
+              return (
+                <div key={conversation.id} className="flex items-start gap-3 rounded-lg border border-border/60 bg-background p-4">
+                  <Avatar className="h-10 w-10">
+                    <AvatarImage src={conversation.participants?.[0]?.avatarUrl || undefined} alt={participantName} />
+                    <AvatarFallback>{buildAvatarFallback(participantName)}</AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 space-y-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-medium text-sm text-foreground">{participantName}</p>
+                      {lastMessageTime && (
+                        <span className="text-xs text-muted-foreground">{lastMessageTime}</span>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {buildPreview(conversation.lastMessage)}
+                    </p>
+                    <div className="flex items-center justify-between pt-2">
+                      <Button asChild size="sm" variant="ghost" className="px-0 text-primary">
+                        <Link href={`/messages/${conversation.id}`}>
+                          {commonT('view')}
+                          <ArrowRight className="ml-2 h-4 w-4" />
+                        </Link>
+                      </Button>
+                      {unreadCount > 0 && (
+                        <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+                          {t('clientSections.recentMessages.unread', { count: unreadCount })}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/client/upcoming-sessions.tsx
+++ b/src/components/dashboard/client/upcoming-sessions.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Calendar, Clock, ExternalLink, Video } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from '@/i18n/routing';
+import type { Session } from '@/types';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface ClientUpcomingSessionsProps {
+  userId: string;
+  locale: string;
+  translations: DashboardTranslations;
+}
+
+interface SessionsResponse {
+  data?: Session[];
+}
+
+const UPCOMING_LIMIT = 2;
+
+async function fetchClientUpcomingSessions(userId: string): Promise<Session[]> {
+  const params = new URLSearchParams({
+    clientId: userId,
+    status: 'scheduled',
+    sortOrder: 'asc',
+    limit: String(UPCOMING_LIMIT * 2),
+  });
+
+  const response = await fetch(`/api/sessions?${params.toString()}`, {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch upcoming sessions');
+  }
+
+  const payload: SessionsResponse = await response.json();
+  const now = new Date();
+  return (payload.data ?? [])
+    .filter((session) => {
+      const scheduled = new Date(session.scheduledAt);
+      return Number.isFinite(scheduled.getTime()) && scheduled >= now;
+    })
+    .sort((a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime())
+    .slice(0, UPCOMING_LIMIT);
+}
+
+export function ClientUpcomingSessions({ userId, locale, translations }: ClientUpcomingSessionsProps) {
+  const { dashboard: t, common: commonT } = translations;
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: 'long',
+        hour: '2-digit',
+        minute: '2-digit',
+        month: 'short',
+        day: 'numeric',
+      }),
+    [locale]
+  );
+
+  const {
+    data: sessions,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<Session[]>({
+    queryKey: ['client-upcoming-sessions', userId],
+    queryFn: () => fetchClientUpcomingSessions(userId),
+    enabled: Boolean(userId),
+    staleTime: 60_000,
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Calendar className="h-5 w-5" />
+          {t('clientSections.upcomingSessions.title')}
+        </CardTitle>
+        <CardDescription>{t('clientSections.upcomingSessions.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading && (
+          <div className="space-y-3">
+            {Array.from({ length: UPCOMING_LIMIT }).map((_, index) => (
+              <div key={`upcoming-session-skeleton-${index}`} className="rounded-lg border p-4">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="mt-2 h-3 w-32" />
+                <Skeleton className="mt-3 h-9 w-full" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>{t('clientSections.upcomingSessions.error')}</p>
+            <Button onClick={() => refetch()} size="sm" variant="outline" className="mt-3">
+              {commonT('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && (sessions?.length ?? 0) === 0 && (
+          <div className="py-10 text-center text-muted-foreground">
+            <Calendar className="mx-auto mb-4 h-12 w-12 opacity-50" />
+            <p>{t('clientSections.upcomingSessions.empty')}</p>
+            <Button asChild variant="outline" className="mt-4">
+              <Link href="/client/book" locale={locale}>
+                {t('clientSections.upcomingSessions.cta')}
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && (sessions?.length ?? 0) > 0 && (
+          <div className="space-y-3">
+            {sessions?.map((session) => {
+              const scheduledAt = new Date(session.scheduledAt);
+              const coachName = `${session.coach.firstName ?? ''} ${session.coach.lastName ?? ''}`.trim() ||
+                session.coach.email;
+
+              return (
+                <div
+                  key={session.id}
+                  className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <p className="font-semibold text-foreground">{session.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {t('clientSections.upcomingSessions.with')} {coachName}
+                    </p>
+                    <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Clock className="h-4 w-4" />
+                      {dateFormatter.format(scheduledAt)}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button asChild size="sm" variant="outline">
+                      <Link href={`/sessions/${session.id}`} locale={locale}>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        {commonT('view')}
+                      </Link>
+                    </Button>
+                    {session.meetingUrl && (
+                      <Button asChild size="sm">
+                        <a
+                          href={session.meetingUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <Video className="mr-2 h-4 w-4" />
+                          {t('clientSections.upcomingSessions.join')}
+                        </a>
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/coach/client-snapshot.tsx
+++ b/src/components/dashboard/coach/client-snapshot.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { CheckCircle, Users } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from '@/i18n/routing';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface CoachStats {
+  totalSessions: number;
+  completedSessions: number;
+  upcomingSessions: number;
+  totalClients: number;
+  activeClients: number;
+}
+
+interface CoachClient {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  status: 'active' | 'inactive';
+  nextSession?: string;
+  lastSession?: string;
+}
+
+interface ClientSnapshotData {
+  stats: CoachStats;
+  clients: CoachClient[];
+}
+
+async function fetchClientSnapshot(): Promise<ClientSnapshotData> {
+  const [statsResponse, clientsResponse] = await Promise.all([
+    fetch('/api/coach/stats', { cache: 'no-store', credentials: 'same-origin' }),
+    fetch('/api/coach/clients?limit=12', { cache: 'no-store', credentials: 'same-origin' }),
+  ]);
+
+  if (!statsResponse.ok) {
+    throw new Error('Failed to fetch coach stats');
+  }
+
+  const statsPayload = await statsResponse.json();
+  const stats: CoachStats = {
+    totalSessions: statsPayload.data?.totalSessions ?? 0,
+    completedSessions: statsPayload.data?.completedSessions ?? 0,
+    upcomingSessions: statsPayload.data?.upcomingSessions ?? 0,
+    totalClients: statsPayload.data?.totalClients ?? 0,
+    activeClients: statsPayload.data?.activeClients ?? 0,
+  };
+
+  let clients: CoachClient[] = [];
+  if (clientsResponse.ok) {
+    const clientsPayload = await clientsResponse.json();
+    clients = (clientsPayload.data ?? []) as CoachClient[];
+  }
+
+  return { stats, clients };
+}
+
+export function CoachClientSnapshot({ translations }: { translations: DashboardTranslations }) {
+  const { dashboard: t, common: commonT } = translations;
+
+  const { data, isLoading, isError, refetch } = useQuery<ClientSnapshotData>({
+    queryKey: ['coach-client-snapshot'],
+    queryFn: fetchClientSnapshot,
+    staleTime: 60_000,
+  });
+
+  const pendingClients = data?.clients.filter((client) => client.status === 'inactive') ?? [];
+
+  const nextSessions = useMemo(() => {
+    return (data?.clients ?? [])
+      .filter((client) => client.nextSession)
+      .sort((a, b) =>
+        new Date(a.nextSession ?? 0).getTime() - new Date(b.nextSession ?? 0).getTime()
+      )
+      .slice(0, 3);
+  }, [data?.clients]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          {t('coachSections.clientSnapshot.title')}
+        </CardTitle>
+        <CardDescription>{t('coachSections.clientSnapshot.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading && (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={`client-snapshot-skeleton-${index}`} className="rounded-lg border p-4">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="mt-2 h-3 w-24" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>{t('coachSections.clientSnapshot.error')}</p>
+            <Button onClick={() => refetch()} size="sm" variant="outline" className="mt-3">
+              {commonT('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && data && (
+          <div className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('coachSections.clientSnapshot.activeClients')}
+                </p>
+                <p className="text-2xl font-semibold text-foreground">{data.stats.activeClients}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('coachSections.clientSnapshot.totalClients')}
+                </p>
+                <p className="text-2xl font-semibold text-foreground">{data.stats.totalClients}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('coachSections.clientSnapshot.pendingRequests')}
+                </p>
+                <p className="text-2xl font-semibold text-foreground">{pendingClients.length}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('coachSections.clientSnapshot.completedSessions')}
+                </p>
+                <p className="text-2xl font-semibold text-foreground">{data.stats.completedSessions}</p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-foreground">
+                  {t('coachSections.clientSnapshot.nextSessions')}
+                </h3>
+                <Button asChild size="sm" variant="ghost" className="px-0 text-primary">
+                  <Link href="/coach/clients">{t('coachSections.clientSnapshot.viewAll')}</Link>
+                </Button>
+              </div>
+
+              {nextSessions.length === 0 ? (
+                <p className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 p-4 text-xs text-muted-foreground">
+                  {t('coachSections.clientSnapshot.noUpcoming')}
+                </p>
+              ) : (
+                <ul className="space-y-2 text-sm">
+                  {nextSessions.map((client) => {
+                    const name = `${client.firstName} ${client.lastName}`.trim() || client.email;
+                    const scheduledAt = client.nextSession
+                      ? new Date(client.nextSession)
+                      : undefined;
+
+                    return (
+                      <li
+                        key={client.id}
+                        className="flex items-center justify-between rounded-lg border border-border/60 bg-background p-3"
+                      >
+                        <div>
+                          <p className="font-medium text-foreground">{name}</p>
+                          {scheduledAt && (
+                            <p className="text-xs text-muted-foreground">
+                              {t('coachSections.clientSnapshot.sessionScheduled', {
+                                date: scheduledAt.toLocaleDateString(),
+                              })}
+                            </p>
+                          )}
+                        </div>
+                        <Button asChild size="sm" variant="outline">
+                          <Link href={`/coach/clients/${client.id}`}>
+                            <CheckCircle className="mr-2 h-4 w-4" />
+                            {t('coachSections.clientSnapshot.openProfile')}
+                          </Link>
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/coach/coach-dashboard.tsx
+++ b/src/components/dashboard/coach/coach-dashboard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { CoachClientSnapshot } from './client-snapshot';
+import { CoachQuickActions } from './quick-actions';
+import { CoachRecentActivityFeed } from './recent-activity-feed';
+import { CoachTodaysAgenda } from './todays-agenda';
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface CoachDashboardProps {
+  userId: string;
+  locale: string;
+  translations: DashboardTranslations;
+  userName: string;
+}
+
+export function CoachDashboard({ userId, locale, translations, userName }: CoachDashboardProps) {
+  return (
+    <div className="space-y-6 lg:space-y-8">
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <CoachTodaysAgenda userId={userId} locale={locale} translations={translations} />
+          <CoachRecentActivityFeed locale={locale} translations={translations} />
+        </div>
+        <div className="space-y-6">
+          <CoachQuickActions translations={translations} userName={userName} />
+          <CoachClientSnapshot translations={translations} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/coach/quick-actions.tsx
+++ b/src/components/dashboard/coach/quick-actions.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Calendar, PlusCircle, Settings } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Link } from '@/i18n/routing';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface CoachQuickActionsProps {
+  translations: DashboardTranslations;
+  userName: string;
+}
+
+const coachActions = [
+  {
+    key: 'add-client',
+    icon: PlusCircle,
+    href: '/coach/clients',
+    labelKey: 'coachSections.quickActions.addClient',
+  },
+  {
+    key: 'view-calendar',
+    icon: Calendar,
+    href: '/sessions',
+    labelKey: 'coachSections.quickActions.viewCalendar',
+  },
+  {
+    key: 'manage-availability',
+    icon: Settings,
+    href: '/coach/availability',
+    labelKey: 'coachSections.quickActions.manageAvailability',
+  },
+] as const;
+
+export function CoachQuickActions({ translations, userName }: CoachQuickActionsProps) {
+  const { dashboard: t } = translations;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Calendar className="h-5 w-5" />
+          {t('coachSections.quickActions.title', { name: userName.split(' ')[0] || userName })}
+        </CardTitle>
+        <CardDescription>{t('coachSections.quickActions.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {coachActions.map((action) => (
+          <Button key={action.key} asChild variant="outline" className="w-full justify-start">
+            <Link href={action.href}>
+              <action.icon className="mr-2 h-4 w-4" />
+              {t(action.labelKey)}
+            </Link>
+          </Button>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/coach/recent-activity-feed.tsx
+++ b/src/components/dashboard/coach/recent-activity-feed.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Activity, CheckCircle2, Clock, FileText, Users } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from '@/i18n/routing';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+type ActivityType = 'session_completed' | 'note_added' | 'client_joined' | 'session_scheduled';
+
+interface CoachActivityItem {
+  id: string;
+  type: ActivityType;
+  description: string;
+  timestamp: string;
+  clientName?: string;
+}
+
+async function fetchRecentActivity(): Promise<CoachActivityItem[]> {
+  const response = await fetch('/api/coach/activity?limit=6', {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch coach activity');
+  }
+
+  const payload = await response.json();
+  return payload.data ?? [];
+}
+
+function resolveIcon(type: ActivityType) {
+  switch (type) {
+    case 'session_completed':
+      return CheckCircle2;
+    case 'session_scheduled':
+      return Clock;
+    case 'note_added':
+      return FileText;
+    case 'client_joined':
+    default:
+      return Users;
+  }
+}
+
+export function CoachRecentActivityFeed({ locale, translations }: { locale: string; translations: DashboardTranslations }) {
+  const { dashboard: t, common: commonT } = translations;
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+        month: 'short',
+        day: 'numeric',
+      }),
+    [locale]
+  );
+
+  const { data, isLoading, isError, refetch } = useQuery<CoachActivityItem[]>({
+    queryKey: ['coach-recent-activity'],
+    queryFn: fetchRecentActivity,
+    staleTime: 30_000,
+  });
+
+  const items = data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Activity className="h-5 w-5" />
+          {t('coachSections.activityFeed.title')}
+        </CardTitle>
+        <CardDescription>{t('coachSections.activityFeed.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading && (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={`activity-skeleton-${index}`} className="flex items-center gap-3 rounded-lg border p-4">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>{t('coachSections.activityFeed.error')}</p>
+            <Button onClick={() => refetch()} size="sm" variant="outline" className="mt-3">
+              {commonT('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && items.length === 0 && (
+          <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            <Activity className="mx-auto mb-3 h-10 w-10 opacity-40" />
+            <p>{t('coachSections.activityFeed.empty')}</p>
+          </div>
+        )}
+
+        {!isLoading && !isError && items.length > 0 && (
+          <ul className="space-y-3">
+            {items.map((item) => {
+              const Icon = resolveIcon(item.type);
+              return (
+                <li key={item.id} className="flex items-start gap-3 rounded-lg border border-border/60 bg-background p-4">
+                  <div className="rounded-full bg-primary/10 p-2">
+                    <Icon className="h-4 w-4 text-primary" />
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <p className="text-sm font-medium text-foreground">{item.description}</p>
+                    {item.clientName && (
+                      <p className="text-xs text-muted-foreground">
+                        {t('coachSections.activityFeed.with', { name: item.clientName })}
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      {timeFormatter.format(new Date(item.timestamp))}
+                    </p>
+                  </div>
+                  <Button asChild size="sm" variant="ghost" className="px-0 text-primary">
+                    <Link href="/coach/clients">{t('coachSections.activityFeed.viewClient')}</Link>
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/coach/todays-agenda.tsx
+++ b/src/components/dashboard/coach/todays-agenda.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { CalendarClock, ExternalLink, User } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from '@/i18n/routing';
+import type { Session } from '@/types';
+
+import type { DashboardTranslations } from '../dashboard-types';
+
+interface CoachTodaysAgendaProps {
+  userId: string;
+  locale: string;
+  translations: DashboardTranslations;
+}
+
+interface SessionsResponse {
+  data?: Session[];
+}
+
+async function fetchTodaysAgenda(userId: string): Promise<Session[]> {
+  const now = new Date();
+  const startOfDay = new Date(now);
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date(now);
+  endOfDay.setHours(23, 59, 59, 999);
+
+  const params = new URLSearchParams({
+    coachId: userId,
+    status: 'scheduled',
+    from: startOfDay.toISOString(),
+    to: endOfDay.toISOString(),
+    sortOrder: 'asc',
+    limit: '10',
+  });
+
+  const response = await fetch(`/api/sessions?${params.toString()}`, {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch agenda');
+  }
+
+  const payload: SessionsResponse = await response.json();
+  return (payload.data ?? []).sort(
+    (a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
+  );
+}
+
+export function CoachTodaysAgenda({ userId, locale, translations }: CoachTodaysAgendaProps) {
+  const { dashboard: t, common: commonT } = translations;
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+    [locale]
+  );
+
+  const dateLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+      }),
+    [locale]
+  );
+
+  const {
+    data: sessions,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<Session[]>({
+    queryKey: ['coach-todays-agenda', userId],
+    queryFn: () => fetchTodaysAgenda(userId),
+    enabled: Boolean(userId),
+    staleTime: 30_000,
+  });
+
+  const agenda = sessions ?? [];
+  const agendaDate = agenda[0]?.scheduledAt ? new Date(agenda[0].scheduledAt) : new Date();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <CalendarClock className="h-5 w-5" />
+          {t('coachSections.todaysAgenda.title')}
+        </CardTitle>
+        <CardDescription>
+          {t('coachSections.todaysAgenda.subtitle', { date: dateLabelFormatter.format(agendaDate) })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading && (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={`agenda-skeleton-${index}`} className="flex items-center gap-3 rounded-lg border p-4">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+                <Skeleton className="h-9 w-24" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>{t('coachSections.todaysAgenda.error')}</p>
+            <Button onClick={() => refetch()} size="sm" variant="outline" className="mt-3">
+              {commonT('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && agenda.length === 0 && (
+          <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+            <CalendarClock className="mx-auto mb-3 h-12 w-12 opacity-40" />
+            <p>{t('coachSections.todaysAgenda.empty')}</p>
+            <Button asChild variant="secondary" className="mt-4">
+              <Link href="/sessions/new">
+                {t('coachSections.todaysAgenda.cta')}
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && agenda.length > 0 && (
+          <ol className="space-y-3">
+            {agenda.map((session) => {
+              const clientName = `${session.client.firstName ?? ''} ${session.client.lastName ?? ''}`.trim() ||
+                session.client.email;
+
+              return (
+                <li
+                  key={session.id}
+                  className="flex flex-col gap-3 rounded-lg border border-border/60 bg-background p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-full bg-primary/10 p-2">
+                      <User className="h-4 w-4 text-primary" />
+                    </div>
+                    <div>
+                      <p className="font-medium text-sm text-foreground">{session.title}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {clientName} • {timeFormatter.format(new Date(session.scheduledAt))}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <Button asChild size="sm" variant="outline">
+                      <Link href={`/sessions/${session.id}`}>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        {t('coachSections.todaysAgenda.viewDetails')}
+                      </Link>
+                    </Button>
+                    {session.meetingUrl && (
+                      <Button asChild size="sm">
+                        <a href={session.meetingUrl} target="_blank" rel="noopener noreferrer">
+                          {t('coachSections.todaysAgenda.startSession')}
+                        </a>
+                      </Button>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,506 +1,37 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import type { LucideIcon } from 'lucide-react';
-import {
-  Calendar,
-  CheckCircle,
-  Clock,
-  DollarSign,
-  Flame,
-  MessageSquare,
-  Smile,
-  Star,
-  Target,
-  TrendingUp,
-  UserCheck,
-  Users,
-} from 'lucide-react';
-import { useMemo } from 'react';
-
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Link } from '@/i18n/routing';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useUser } from '@/lib/store/auth-store';
-import type { Session } from '@/types';
+
+import { ClientDashboard } from './client/client-dashboard';
+import { CoachDashboard } from './coach/coach-dashboard';
+import type { DashboardTranslations } from './dashboard-types';
 
 interface DashboardContentProps {
-  translations: {
-    dashboard: (key: string, values?: Record<string, unknown>) => string;
-    common: (key: string) => string;
-  };
+  translations: DashboardTranslations;
   locale: string;
-}
-
-type UserRole = 'coach' | 'client' | 'admin' | string;
-
-interface CoachStats {
-  totalSessions: number;
-  completedSessions: number;
-  upcomingSessions: number;
-  totalClients: number;
-  activeClients: number;
-  thisWeekSessions: number;
-  averageRating: number;
-  totalRevenue: number;
-}
-
-interface ClientStats {
-  totalSessions: number;
-  completedSessions: number;
-  upcomingSessions: number;
-  totalReflections: number;
-  thisWeekSessions: number;
-  averageMoodRating: number;
-  goalsAchieved: number;
-  currentStreak: number;
-}
-
-interface AdminOverview {
-  totalUsers: number;
-  activeUsers: number;
-  totalSessions: number;
-  completedSessions: number;
-  revenue: number;
-  averageRating: number;
-  newUsersThisMonth: number;
-  completionRate: number;
-  totalCoaches: number;
-  totalClients: number;
-  activeCoaches: number;
-  averageSessionsPerUser: number;
-}
-
-interface DashboardResult {
-  stats: CoachStats | ClientStats | AdminOverview;
-  upcomingSessions: Session[];
-}
-
-interface StatCardConfig {
-  key: string;
-  title: string;
-  value: string;
-  helper?: string;
-  icon: LucideIcon;
-}
-
-type AppRoute = Parameters<typeof Link>[0]['href'];
-
-interface QuickActionConfig {
-  key: string;
-  label: string;
-  icon: LucideIcon;
-  href: AppRoute;
-}
-
-const UPCOMING_LIMIT = 5;
-const DEFAULT_CURRENCY = 'USD';
-
-const resolveCurrency = (locale: string) => {
-  if (locale?.startsWith('he')) {
-    return 'ILS';
-  }
-  return DEFAULT_CURRENCY;
-};
-
-const defaultCoachStats: CoachStats = {
-  totalSessions: 0,
-  completedSessions: 0,
-  upcomingSessions: 0,
-  totalClients: 0,
-  activeClients: 0,
-  thisWeekSessions: 0,
-  averageRating: 0,
-  totalRevenue: 0,
-};
-
-const defaultClientStats: ClientStats = {
-  totalSessions: 0,
-  completedSessions: 0,
-  upcomingSessions: 0,
-  totalReflections: 0,
-  thisWeekSessions: 0,
-  averageMoodRating: 0,
-  goalsAchieved: 0,
-  currentStreak: 0,
-};
-
-const defaultAdminOverview: AdminOverview = {
-  totalUsers: 0,
-  activeUsers: 0,
-  totalSessions: 0,
-  completedSessions: 0,
-  revenue: 0,
-  averageRating: 0,
-  newUsersThisMonth: 0,
-  completionRate: 0,
-  totalCoaches: 0,
-  totalClients: 0,
-  activeCoaches: 0,
-  averageSessionsPerUser: 0,
-};
-
-async function fetchDashboardData(role: UserRole, userId: string): Promise<DashboardResult> {
-  const statsUrl = role === 'coach'
-    ? '/api/coach/stats'
-    : role === 'client'
-      ? '/api/client/stats'
-      : '/api/admin/dashboard?timeRange=30d';
-
-  const sessionQuery = new URLSearchParams({
-    status: 'scheduled',
-    sortOrder: 'asc',
-    limit: String(UPCOMING_LIMIT),
-  });
-
-  if (role === 'coach') {
-    sessionQuery.set('coachId', userId);
-  } else if (role === 'client') {
-    sessionQuery.set('clientId', userId);
-  }
-
-  const [statsResponse, sessionsResponse] = await Promise.all([
-    fetch(statsUrl, { cache: 'no-store', credentials: 'same-origin' }),
-    fetch(`/api/sessions?${sessionQuery.toString()}`, { cache: 'no-store', credentials: 'same-origin' }),
-  ]);
-
-  if (!statsResponse.ok) {
-    throw new Error('Failed to load dashboard statistics');
-  }
-
-  const statsPayload = await statsResponse.json();
-  let stats: CoachStats | ClientStats | AdminOverview;
-
-  if (role === 'coach') {
-    stats = {
-      ...defaultCoachStats,
-      ...((statsPayload.data ?? {}) as Partial<CoachStats>),
-    };
-  } else if (role === 'client') {
-    stats = {
-      ...defaultClientStats,
-      ...((statsPayload.data ?? {}) as Partial<ClientStats>),
-    };
-  } else {
-    const overview = (statsPayload.data?.overview ?? {}) as Partial<AdminOverview>;
-    stats = {
-      ...defaultAdminOverview,
-      ...overview,
-    };
-  }
-
-  let upcomingSessions: Session[] = [];
-  if (sessionsResponse.ok) {
-    try {
-      const sessionsPayload = await sessionsResponse.json();
-      const sessions = (sessionsPayload.data ?? []) as Session[];
-      const now = new Date();
-      upcomingSessions = sessions
-        .filter((session) => {
-          const scheduled = new Date(session.scheduledAt);
-          return Number.isFinite(scheduled.getTime()) && scheduled >= now;
-        })
-        .slice(0, UPCOMING_LIMIT);
-    } catch (error) {
-      console.warn('Failed to parse upcoming sessions payload', error);
-    }
-  }
-
-  return { stats, upcomingSessions };
-}
-
-function buildDisplayName(person?: { firstName?: string | null; lastName?: string | null; email?: string | null }) {
-  if (!person) {
-    return '—';
-  }
-  const segments = [person.firstName, person.lastName].filter(Boolean);
-  const fullName = segments.join(' ');
-  return fullName || person.email || '—';
 }
 
 export function DashboardContent({ translations, locale }: DashboardContentProps) {
   const user = useUser();
-  const { dashboard: t, common: commonT } = translations;
-
-  const numberFormatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
-  const currencyFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat(locale, {
-        style: 'currency',
-        currency: resolveCurrency(locale),
-        maximumFractionDigits: 0,
-      }),
-    [locale]
-  );
-  const decimalFormatter = useMemo(
-    () => new Intl.NumberFormat(locale, { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-    [locale]
-  );
-  const dateTimeFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      }),
-    [locale]
-  );
-
-  const role = user?.role as UserRole | undefined;
-
-  const { data, isLoading, isError } = useQuery<DashboardResult>({
-    queryKey: ['dashboard-overview', user?.id, role],
-    queryFn: () => fetchDashboardData(role ?? 'client', user!.id),
-    enabled: Boolean(user?.id && role),
-    staleTime: 60_000,
-  });
-
-  const statsCards = useMemo<StatCardConfig[]>(() => {
-    if (!user?.role || !data?.stats) {
-      return [];
-    }
-
-    if (user.role === 'coach') {
-      const stats = data.stats as CoachStats;
-      return [
-        {
-          key: 'total-sessions',
-          title: t('stats.totalSessions'),
-          value: numberFormatter.format(stats.totalSessions),
-          helper: t('stats.allTime'),
-          icon: Calendar,
-        },
-        {
-          key: 'upcoming-sessions',
-          title: t('stats.upcomingSessions'),
-          value: numberFormatter.format(stats.upcomingSessions),
-          helper: t('stats.thisWeek'),
-          icon: Clock,
-        },
-        {
-          key: 'completed-sessions',
-          title: t('stats.completedSessions'),
-          value: numberFormatter.format(stats.completedSessions),
-          helper: t('stats.thisMonth'),
-          icon: CheckCircle,
-        },
-        {
-          key: 'active-clients',
-          title: t('stats.activeClients'),
-          value: numberFormatter.format(stats.activeClients || stats.totalClients),
-          helper: t('stats.total'),
-          icon: Users,
-        },
-        {
-          key: 'average-rating',
-          title: t('stats.averageRating'),
-          value: stats.averageRating > 0 ? decimalFormatter.format(stats.averageRating) : '—',
-          helper: t('stats.allTime'),
-          icon: Star,
-        },
-        {
-          key: 'revenue',
-          title: t('stats.totalRevenue'),
-          value: currencyFormatter.format(stats.totalRevenue || 0),
-          helper: t('stats.thisMonth'),
-          icon: DollarSign,
-        },
-      ];
-    }
-
-    if (user.role === 'client') {
-      const stats = data.stats as ClientStats;
-      return [
-        {
-          key: 'total-sessions',
-          title: t('stats.totalSessions'),
-          value: numberFormatter.format(stats.totalSessions),
-          helper: t('stats.allTime'),
-          icon: Calendar,
-        },
-        {
-          key: 'upcoming-sessions',
-          title: t('stats.upcomingSessions'),
-          value: numberFormatter.format(stats.upcomingSessions),
-          helper: t('stats.thisWeek'),
-          icon: Clock,
-        },
-        {
-          key: 'completed-sessions',
-          title: t('stats.completedSessions'),
-          value: numberFormatter.format(stats.completedSessions),
-          helper: t('stats.thisMonth'),
-          icon: CheckCircle,
-        },
-        {
-          key: 'reflections',
-          title: t('stats.totalReflections'),
-          value: numberFormatter.format(stats.totalReflections),
-          helper: t('stats.allTime'),
-          icon: MessageSquare,
-        },
-        {
-          key: 'average-mood',
-          title: t('stats.averageMood'),
-          value: stats.averageMoodRating > 0 ? decimalFormatter.format(stats.averageMoodRating) : '—',
-          helper: t('stats.allTime'),
-          icon: Smile,
-        },
-        {
-          key: 'goals-achieved',
-          title: t('stats.goalsAchieved'),
-          value: numberFormatter.format(stats.goalsAchieved),
-          helper: t('stats.allTime'),
-          icon: Target,
-        },
-        {
-          key: 'current-streak',
-          title: t('stats.currentStreak'),
-          value: numberFormatter.format(stats.currentStreak),
-          helper: t('stats.thisWeek'),
-          icon: Flame,
-        },
-      ];
-    }
-
-    const stats = data.stats as AdminOverview;
-    return [
-      {
-        key: 'total-users',
-        title: t('stats.totalUsers'),
-        value: numberFormatter.format(stats.totalUsers),
-        helper: t('stats.allTime'),
-        icon: Users,
-      },
-      {
-        key: 'active-users',
-        title: t('stats.activeUsers'),
-        value: numberFormatter.format(stats.activeUsers),
-        helper: t('stats.thisMonth'),
-        icon: UserCheck,
-      },
-      {
-        key: 'platform-sessions',
-        title: t('stats.totalSessions'),
-        value: numberFormatter.format(stats.totalSessions),
-        helper: t('stats.thisMonth'),
-        icon: Calendar,
-      },
-      {
-        key: 'platform-completed',
-        title: t('stats.completedSessions'),
-        value: numberFormatter.format(stats.completedSessions),
-        helper: t('stats.thisMonth'),
-        icon: CheckCircle,
-      },
-      {
-        key: 'platform-revenue',
-        title: t('stats.totalRevenue'),
-        value: currencyFormatter.format(stats.revenue || 0),
-        helper: t('stats.thisMonth'),
-        icon: DollarSign,
-      },
-      {
-        key: 'active-coaches',
-        title: t('stats.activeCoaches'),
-        value: numberFormatter.format(stats.activeCoaches),
-        helper: t('stats.thisMonth'),
-        icon: Users,
-      },
-    ];
-  }, [user?.role, data?.stats, t, numberFormatter, currencyFormatter, decimalFormatter]);
-
-  const upcomingSessions = data?.upcomingSessions ?? [];
-
-  const quickActions = useMemo<QuickActionConfig[]>(() => {
-    if (!user?.role) {
-      return [];
-    }
-
-    if (user.role === 'coach') {
-      return [
-        {
-          key: 'schedule-session',
-          label: t('quickActions.scheduleSession'),
-          icon: Calendar,
-          href: '/sessions/new' as AppRoute,
-        },
-        {
-          key: 'view-clients',
-          label: t('quickActions.viewClients'),
-          icon: Users,
-          href: '/coach/clients' as AppRoute,
-        },
-        {
-          key: 'add-note',
-          label: t('quickActions.addNote'),
-          icon: MessageSquare,
-          href: '/coach/notes' as AppRoute,
-        },
-      ];
-    }
-
-    if (user.role === 'client') {
-      return [
-        {
-          key: 'book-session',
-          label: t('quickActions.bookSession'),
-          icon: Calendar,
-          href: '/client/book' as AppRoute,
-        },
-        {
-          key: 'add-reflection',
-          label: t('quickActions.addReflection'),
-          icon: MessageSquare,
-          href: '/client/reflections' as AppRoute,
-        },
-        {
-          key: 'view-progress',
-          label: t('quickActions.viewProgress'),
-          icon: TrendingUp,
-          href: '/client/progress' as AppRoute,
-        },
-      ];
-    }
-
-    return [
-      {
-        key: 'manage-users',
-        label: t('quickActions.manageUsers'),
-        icon: Users,
-      href: '/admin/users' as AppRoute,
-      },
-      {
-        key: 'review-analytics',
-        label: t('quickActions.reviewAnalytics'),
-        icon: TrendingUp,
-      href: '/admin/analytics' as AppRoute,
-      },
-      {
-        key: 'system-health',
-        label: t('quickActions.systemHealth'),
-        icon: UserCheck,
-      href: '/admin/system' as AppRoute,
-      },
-    ];
-  }, [user?.role, t]);
 
   if (!user) {
-    return null; // RouteGuard handles redirects
+    return null;
   }
 
-  const roleVariant = user.role === 'admin' ? 'default' : user.role === 'coach' ? 'secondary' : 'outline';
-  const roleLabel = user.role === 'admin' ? t('roles.admin') : user.role === 'coach' ? t('roles.coach') : t('roles.client');
+  const { dashboard: t } = translations;
+
+  const role = user.role;
+  const roleVariant =
+    role === 'admin' ? 'default' : role === 'coach' ? 'secondary' : 'outline';
+  const roleLabel =
+    role === 'admin' ? t('roles.admin') : role === 'coach' ? t('roles.coach') : t('roles.client');
 
   return (
     <>
       <div className="border-b bg-card/60 backdrop-blur supports-[backdrop-filter]:backdrop-blur-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="page-title text-foreground">
@@ -514,145 +45,35 @@ export function DashboardContent({ translations, locale }: DashboardContentProps
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
-        {isError && (
-          <div
-            className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
-            aria-live="polite"
-          >
-            {t('loadError')}
-          </div>
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {role === 'coach' && (
+          <CoachDashboard
+            userId={user.id}
+            locale={locale}
+            translations={translations}
+            userName={user.firstName || user.email}
+          />
         )}
-
-        <div
-          className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"
-          data-testid="dashboard-stats-grid"
-        >
-          {isLoading
-            ? Array.from({ length: (() => {
-                  if (!user?.role) {
-                    return 4;
-                  }
-                  if (user.role === 'client') {
-                    return 7;
-                  }
-                  return 6;
-                })() }).map((_, index) => (
-                <Card key={`stats-skeleton-${index}`}>
-                  <CardHeader className="space-y-2 pb-2">
-                    <Skeleton className="h-4 w-24" />
-                    <Skeleton className="h-4 w-16" />
-                  </CardHeader>
-                  <CardContent>
-                    <Skeleton className="h-8 w-24" />
-                    <Skeleton className="mt-2 h-3 w-20" />
-                  </CardContent>
-                </Card>
-              ))
-            : statsCards.map((card) => (
-                <Card key={card.key}>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
-                    <card.icon className="h-4 w-4 text-muted-foreground" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{card.value}</div>
-                    {card.helper && (
-                      <p className="text-xs text-muted-foreground">{card.helper}</p>
-                    )}
-                  </CardContent>
-                </Card>
-              ))}
-        </div>
-
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+        {role === 'client' && (
+          <ClientDashboard
+            userId={user.id}
+            locale={locale}
+            translations={translations}
+            userName={user.firstName || user.email}
+          />
+        )}
+        {role !== 'coach' && role !== 'client' && (
           <Card>
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Calendar className="h-5 w-5" />
-                {t('upcomingSessions.title')}
-              </CardTitle>
-              <CardDescription>{t('upcomingSessions.description')}</CardDescription>
+              <CardTitle>{t('adminPlaceholder.title')}</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
-              {isLoading ? (
-                <div className="space-y-3">
-                  {Array.from({ length: 3 }).map((_, index) => (
-                    <div
-                      key={`upcoming-skeleton-${index}`}
-                      className="rounded-lg border p-4"
-                    >
-                      <Skeleton className="h-5 w-32" />
-                      <Skeleton className="mt-2 h-3 w-40" />
-                      <Skeleton className="mt-2 h-3 w-24" />
-                    </div>
-                  ))}
-                </div>
-              ) : upcomingSessions.length > 0 ? (
-                upcomingSessions.map((session) => {
-                  const participantName = user.role === 'coach'
-                    ? buildDisplayName(session.client)
-                    : user.role === 'client'
-                      ? buildDisplayName(session.coach)
-                      : `${buildDisplayName(session.coach)} • ${buildDisplayName(session.client)}`;
-
-                  return (
-                    <div
-                      key={session.id}
-                      className="flex items-center justify-between gap-4 rounded-lg border p-4"
-                    >
-                      <div>
-                        <h4 className="font-medium text-foreground">{session.title}</h4>
-                        <p className="text-sm text-muted-foreground">
-                          {t('upcomingSessions.with')} {participantName}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {dateTimeFormatter.format(new Date(session.scheduledAt))}
-                        </p>
-                      </div>
-                      <Button asChild variant="outline" size="sm" data-testid="view-session-button">
-                        <Link href={`/sessions/${session.id}` as AppRoute} locale={locale}>
-                          {commonT('view')}
-                        </Link>
-                      </Button>
-                    </div>
-                  );
-                })
-              ) : (
-                <div className="py-10 text-center text-muted-foreground">
-                  <Calendar className="mx-auto mb-4 h-12 w-12 opacity-50" />
-                  <p>{t('upcomingSessions.empty')}</p>
-                </div>
-              )}
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                {t('adminPlaceholder.body')}
+              </p>
             </CardContent>
           </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <TrendingUp className="h-5 w-5" />
-                {t('quickActions.title')}
-              </CardTitle>
-              <CardDescription>{t('quickActions.description')}</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {quickActions.map((action) => (
-                <Button
-                  key={action.key}
-                  variant="outline"
-                  className="w-full justify-start"
-                  asChild
-                >
-                  <Link href={action.href as Parameters<typeof Link>[0]['href']} locale={locale}>
-                    <action.icon className="mr-2 h-4 w-4" />
-                    {action.label}
-                  </Link>
-                </Button>
-              ))}
-            </CardContent>
-          </Card>
-        </div>
+        )}
       </div>
     </>
   );

--- a/src/components/dashboard/dashboard-types.ts
+++ b/src/components/dashboard/dashboard-types.ts
@@ -1,0 +1,4 @@
+export interface DashboardTranslations {
+  dashboard: (key: string, values?: Record<string, unknown>) => string;
+  common: (key: string, values?: Record<string, unknown>) => string;
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -196,6 +196,91 @@
       "manageUsers": "Manage Users",
       "reviewAnalytics": "Review Analytics",
       "systemHealth": "System Health"
+    },
+    "adminPlaceholder": {
+      "title": "Administrator dashboard",
+      "body": "We're working on a dedicated experience for administrators. In the meantime you can continue managing the platform from the navigation menu."
+    },
+    "clientSections": {
+      "upcomingSessions": {
+        "title": "Upcoming Sessions",
+        "subtitle": "Stay ready for what's next with your coach",
+        "error": "We couldn't load your upcoming sessions. Please try again.",
+        "empty": "You don't have any upcoming sessions yet.",
+        "cta": "Schedule a session",
+        "with": "with",
+        "join": "Join session"
+      },
+      "recentMessages": {
+        "title": "Recent Messages",
+        "subtitle": "Catch up on conversations with your coach",
+        "error": "We couldn't load your messages. Please try again.",
+        "empty": "No new messages at the moment.",
+        "cta": "Open messages",
+        "unread": "{count} unread"
+      },
+      "goalProgress": {
+        "title": "Goal Progress",
+        "subtitle": "Track how you're progressing toward your goals",
+        "error": "We couldn't load your goals right now.",
+        "empty": "No personal goals just yet. Start a goal to see your progress here.",
+        "cta": "Review my goals",
+        "total": "Total goals",
+        "completed": "Completed",
+        "inProgress": "In progress",
+        "completedLabel": "Completed",
+        "target": "Target: {date}",
+        "highPriority": "High priority",
+        "mediumPriority": "Medium priority",
+        "lowPriority": "Low priority"
+      },
+      "quickActions": {
+        "title": "Shortcuts",
+        "subtitle": "Jump into the tasks you do most often",
+        "schedule": "Schedule a session",
+        "files": "View shared files",
+        "contact": "Message my coach"
+      }
+    },
+    "coachSections": {
+      "todaysAgenda": {
+        "title": "Today's Agenda",
+        "subtitle": "Your schedule for {date}",
+        "error": "We couldn't load today's agenda. Please try again.",
+        "empty": "You have no sessions scheduled today.",
+        "cta": "Schedule a new session",
+        "viewDetails": "View details",
+        "startSession": "Start session"
+      },
+      "clientSnapshot": {
+        "title": "Client Snapshot",
+        "subtitle": "Key metrics about your client roster",
+        "error": "We couldn't load your client overview.",
+        "activeClients": "Active clients",
+        "totalClients": "Total clients",
+        "pendingRequests": "Pending follow-ups",
+        "completedSessions": "Sessions completed",
+        "nextSessions": "Next sessions",
+        "viewAll": "View all clients",
+        "noUpcoming": "No upcoming sessions scheduled.",
+        "sessionScheduled": "Session scheduled • {date}",
+        "openProfile": "Open profile"
+      },
+      "activityFeed": {
+        "title": "Recent Activity",
+        "subtitle": "Updates from your coaching work",
+        "error": "We couldn't load recent activity.",
+        "empty": "No recent updates to show just yet.",
+        "with": "with {name}",
+        "viewClient": "View client"
+      },
+      "quickActions": {
+        "title": "Quick actions for {name}",
+        "subtitle": "Stay on top of your coaching workflow",
+        "addClient": "Add or invite a client",
+        "viewCalendar": "Open calendar",
+        "manageAvailability": "Manage availability"
+      }
     }
   },
   "mfa": {

--- a/src/messages/he.json
+++ b/src/messages/he.json
@@ -287,6 +287,91 @@
       "reviewAnalytics": "צפה באנליטיקה",
       "systemHealth": "בריאות המערכת"
     },
+    "adminPlaceholder": {
+      "title": "לוח ניהול",
+      "body": "אנחנו בונים חוויית אדמין ייעודית. בינתיים ניתן להמשיך לנהל את המערכת דרך תפריט הניווט."
+    },
+    "clientSections": {
+      "upcomingSessions": {
+        "title": "פגישות קרובות",
+        "subtitle": "התכונן למה שמגיע עם המאמן שלך",
+        "error": "לא הצלחנו לטעון את הפגישות הקרובות. נסה שוב.",
+        "empty": "אין לך פגישות קרובות כרגע.",
+        "cta": "קבע פגישה",
+        "with": "עם",
+        "join": "הצטרף לפגישה"
+      },
+      "recentMessages": {
+        "title": "הודעות אחרונות",
+        "subtitle": "הישאר מעודכן בשיחות עם המאמן",
+        "error": "לא הצלחנו לטעון הודעות. נסה שוב.",
+        "empty": "אין הודעות חדשות כרגע.",
+        "cta": "פתח הודעות",
+        "unread": "{count} שלא נקראו"
+      },
+      "goalProgress": {
+        "title": "התקדמות במטרות",
+        "subtitle": "עקוב אחר ההתקדמות שלך",
+        "error": "לא הצלחנו לטעון את המטרות שלך.",
+        "empty": "עוד לא הגדרת מטרות אישיות. התחיל מטרה כדי לראות את ההתקדמות כאן.",
+        "cta": "צפה במטרות שלי",
+        "total": "סה\"כ מטרות",
+        "completed": "הושלמו",
+        "inProgress": "בתהליך",
+        "completedLabel": "הושלמה",
+        "target": "יעד: {date}",
+        "highPriority": "עדיפות גבוהה",
+        "mediumPriority": "עדיפות בינונית",
+        "lowPriority": "עדיפות נמוכה"
+      },
+      "quickActions": {
+        "title": "קיצורי דרך",
+        "subtitle": "גש לפעולות שתבצע הכי הרבה",
+        "schedule": "קבע פגישה",
+        "files": "צפה בקבצים משותפים",
+        "contact": "שלח הודעה למאמן"
+      }
+    },
+    "coachSections": {
+      "todaysAgenda": {
+        "title": "הלו\"ז של היום",
+        "subtitle": "לוח הזמנים שלך ל- {date}",
+        "error": "לא הצלחנו לטעון את לוח הזמנים. נסה שוב.",
+        "empty": "אין פגישות מתוכננות היום.",
+        "cta": "קבע פגישה חדשה",
+        "viewDetails": "צפה בפרטים",
+        "startSession": "התחל פגישה"
+      },
+      "clientSnapshot": {
+        "title": "תמונת מצב לקוחות",
+        "subtitle": "מדדים מרכזיים על רשימת הלקוחות",
+        "error": "לא הצלחנו לטעון את סיכום הלקוחות.",
+        "activeClients": "לקוחות פעילים",
+        "totalClients": "סה\"כ לקוחות",
+        "pendingRequests": "מעקבים ממתינים",
+        "completedSessions": "פגישות שהושלמו",
+        "nextSessions": "הפגישות הקרובות",
+        "viewAll": "צפה בכל הלקוחות",
+        "noUpcoming": "אין פגישות קרובות מתוכננות.",
+        "sessionScheduled": "פגישה מתוכננת • {date}",
+        "openProfile": "פתח פרופיל"
+      },
+      "activityFeed": {
+        "title": "פעילות אחרונה",
+        "subtitle": "עדכונים מהעבודה שלך",
+        "error": "לא הצלחנו לטעון פעילות אחרונה.",
+        "empty": "אין עדכונים חדשים כרגע.",
+        "with": "עם {name}",
+        "viewClient": "צפה בלקוח"
+      },
+      "quickActions": {
+        "title": "פעולות מהירות עבור {name}",
+        "subtitle": "השאר בשליטה על תהליך האימון",
+        "addClient": "הוסף או הזמן לקוח",
+        "viewCalendar": "פתח יומן",
+        "manageAvailability": "נהל זמינות"
+      }
+    },
     "tabs": {
       "overview": "סקירה",
       "sessions": "פגישות",


### PR DESCRIPTION
## Summary
- replace the monolithic dashboard content with a role-aware renderer that shows coach, client, or admin-specific shells
- add dedicated client widgets for upcoming sessions, goal progress, recent messages, and shortcuts powered by live API data
- build the coach dashboard suite with today’s agenda, client snapshot analytics, recent activity feed, and tailored quick actions
- localize the new dashboard sections for both English and Hebrew users

## Testing
- npx eslint src/components/dashboard/dashboard-content.tsx src/components/dashboard/client/*.tsx src/components/dashboard/coach/*.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dcfc4936808320b659e3d5b5b5ee0c