### PR TITLE
Add coverage for session utilities and flows

### DIFF
--- a/src/test/integration/use-filtered-sessions.test.js
+++ b/src/test/integration/use-filtered-sessions.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 vi.mock('@tanstack/react-query', async () => {
   const actual = await vi.importActual('@tanstack/react-query');
   return actual;
@@ -5,7 +6,6 @@ vi.mock('@tanstack/react-query', async () => {
 
 import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { useFilteredSessions } from '@/lib/queries/sessions';
 import {

--- a/src/test/integration/use-filtered-sessions.test.js
+++ b/src/test/integration/use-filtered-sessions.test.js
@@ -1,0 +1,149 @@
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return actual;
+});
+
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { useFilteredSessions } from '@/lib/queries/sessions';
+import {
+  createMockSession,
+  renderWithProviders,
+  createTestQueryClient,
+} from '@/test/utils';
+
+function FilteredSessionsTestComponent({ clientId, options }) {
+  const query = useFilteredSessions(clientId, options);
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('span', { 'data-testid': 'status' }, query.status),
+    React.createElement(
+      'span',
+      { 'data-testid': 'error' },
+      query.error ? 'error' : ''
+    ),
+    React.createElement(
+      'span',
+      { 'data-testid': 'data' },
+      query.data ? JSON.stringify(query.data) : ''
+    )
+  );
+}
+
+describe('useFilteredSessions integration', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('builds the request URL with all provided filters', async () => {
+    const mockResponse = {
+      data: [createMockSession({ id: 'session-1' })],
+      pagination: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(mockResponse),
+    });
+    global.fetch = fetchMock;
+
+    const queryClient = createTestQueryClient();
+    const options = {
+      filters: {
+        status: ['scheduled', 'completed'],
+        dateRange: {
+          from: new Date('2024-01-01T00:00:00Z'),
+          to: new Date('2024-01-31T23:59:59Z'),
+        },
+        sessionType: ['video'],
+        search: ' career coaching ',
+      },
+      sortBy: 'date',
+      sortOrder: 'asc',
+      page: 2,
+      limit: 25,
+      viewMode: 'list',
+    };
+
+    renderWithProviders(
+      React.createElement(FilteredSessionsTestComponent, {
+        clientId: 'client-123',
+        options,
+      }),
+      { queryClient }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('success');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestUrl = fetchMock.mock.calls[0][0];
+    const url = new URL(requestUrl, 'http://localhost');
+
+    expect(url.pathname).toBe('/api/sessions');
+    expect(url.searchParams.get('clientId')).toBe('client-123');
+    expect(url.searchParams.getAll('status')).toEqual([
+      'scheduled',
+      'completed',
+    ]);
+    expect(url.searchParams.get('dateFrom')).toBe('2024-01-01T00:00:00.000Z');
+    expect(url.searchParams.get('dateTo')).toBe('2024-01-31T23:59:59.000Z');
+    expect(url.searchParams.getAll('sessionType')).toEqual(['video']);
+    expect(url.searchParams.get('search')).toBe(' career coaching ');
+    expect(url.searchParams.get('sortBy')).toBe('date');
+    expect(url.searchParams.get('sortOrder')).toBe('asc');
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('limit')).toBe('25');
+
+    const data = screen.getByTestId('data').textContent;
+    expect(data).toBe(JSON.stringify(mockResponse));
+
+    queryClient.clear();
+  });
+
+  it('exposes an error state when the request fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn(),
+    });
+    global.fetch = fetchMock;
+
+    const queryClient = createTestQueryClient();
+
+    renderWithProviders(
+      React.createElement(FilteredSessionsTestComponent, {
+        clientId: 'client-123',
+        options: { page: 1, limit: 10 },
+      }),
+      { queryClient }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('error');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('error')).toHaveTextContent('error');
+
+    queryClient.clear();
+  });
+});

--- a/src/test/unit/utils/formatting.test.ts
+++ b/src/test/unit/utils/formatting.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  formatDuration,
+  truncateText,
+  createUserProcessor,
+  getInitials,
+} from '@/lib/utils';
+
+describe('formatDuration', () => {
+  it('formats durations under an hour using minutes', () => {
+    expect(formatDuration(45)).toBe('45m');
+    expect(formatDuration(0)).toBe('0m');
+  });
+
+  it('formats durations with hours and minutes for english locales', () => {
+    expect(formatDuration(60)).toBe('1h');
+    expect(formatDuration(125)).toBe('2h 5m');
+  });
+
+  it('formats durations for hebrew locale with localized units', () => {
+    expect(formatDuration(90, 'he')).toBe('1 שעות ו-30 דקות');
+    expect(formatDuration(50, 'he')).toBe('50 דקות');
+  });
+});
+
+describe('truncateText', () => {
+  it('returns the original text when below the limit', () => {
+    expect(truncateText('Hello', 10)).toBe('Hello');
+  });
+
+  it('truncates and appends ellipsis when above the limit', () => {
+    expect(truncateText('Hello World', 5)).toBe('Hello...');
+  });
+});
+
+describe('createUserProcessor', () => {
+  const processor = createUserProcessor();
+
+  it('derives initials from first and last name', () => {
+    expect(processor.getInitials({ firstName: 'Loom', lastName: 'User' })).toBe(
+      'LU'
+    );
+  });
+
+  it('falls back to name field when available', () => {
+    expect(processor.getInitials({ name: 'Future Coach' })).toBe('FC');
+    expect(processor.getDisplayName({ name: 'Future Coach' })).toBe(
+      'Future Coach'
+    );
+  });
+
+  it('uses email for initials and default display name when minimal data provided', () => {
+    expect(processor.getInitials({ email: 'person@example.com' })).toBe('P');
+    expect(processor.getDisplayName({ email: 'person@example.com' })).toBe(
+      'person@example.com'
+    );
+  });
+
+  it('returns placeholder display name when no user information exists', () => {
+    expect(processor.getDisplayName({})).toBe('Unknown User');
+    expect(processor.getInitials({})).toBe('?');
+  });
+});
+
+describe('getInitials legacy helper', () => {
+  it('delegates to createUserProcessor for backwards compatibility', () => {
+    expect(getInitials('Test', 'User')).toBe('TU');
+    expect(getInitials(undefined, undefined)).toBe('?');
+  });
+});

--- a/tests/sessions/session-management.spec.ts
+++ b/tests/sessions/session-management.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+import { createAuthHelper, testConstants } from '../helpers';
+
+test.describe('Session management flows', () => {
+  test('client can explore sessions page and booking dialog', async ({
+    page,
+  }) => {
+    const authHelper = createAuthHelper(page);
+
+    await authHelper.signInUserByRole('client');
+
+    await page.goto('/sessions');
+
+    const bookSessionButton = page.locator(
+      '[data-testid="book-session-button"]'
+    );
+    await expect(bookSessionButton).toBeVisible();
+
+    const searchInput = page.locator('[data-testid="session-search"]');
+    await expect(searchInput).toBeVisible();
+
+    await bookSessionButton.click();
+    const bookingDialog = page.getByRole('dialog');
+    await expect(bookingDialog).toContainText('Book New Session');
+    await expect(bookingDialog).toContainText(
+      'Choose your preferred coach and an available time slot for your session'
+    );
+
+    await page.keyboard.press('Escape');
+    await expect(bookingDialog).toBeHidden({
+      timeout: testConstants.SHORT_TIMEOUT,
+    });
+
+    const listTab = page.getByRole('tab', { name: 'List View' });
+    const calendarTab = page.getByRole('tab', { name: 'Calendar View' });
+
+    await expect(listTab).toHaveAttribute('data-state', 'active');
+
+    await calendarTab.click();
+    await expect(calendarTab).toHaveAttribute('data-state', 'active');
+    await expect(listTab).toHaveAttribute('data-state', 'inactive');
+
+    await listTab.click();
+    await expect(listTab).toHaveAttribute('data-state', 'active');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering utility helpers for duration formatting, truncation, and user display metadata
- add integration test verifying filtered session query parameters and error handling via renderWithProviders
- add Playwright E2E scenario exercising client session booking entry points and tab switching

## Testing
- npx vitest run src/test/unit/utils/formatting.test.ts src/test/integration/use-filtered-sessions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de19b9b80483209d39dbe08112dbc2