### PR TITLE
Refactor Supabase server client cookie handling

### DIFF
--- a/src/app/api/analytics/dashboard/route.ts
+++ b/src/app/api/analytics/dashboard/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { downloadTrackingDatabase } from '@/lib/database/download-tracking';
 import { fileDatabase } from '@/lib/database/files';
 import { z } from 'zod';
@@ -13,6 +14,8 @@ const dashboardQuerySchema = z.object({
 
 // GET /api/analytics/dashboard - Get user's download analytics dashboard
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Get authenticated user
     const supabase = await createClient();

--- a/src/app/api/debug/environment/route.ts
+++ b/src/app/api/debug/environment/route.ts
@@ -1,4 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
+import { setSupabaseCookieStore } from '@/lib/supabase/server';
 
 /**
  * Environment Debug API Endpoint
@@ -69,6 +71,8 @@ function validateEnvironmentVariable(name: string, value: string | undefined): E
 }
 
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   const { searchParams } = new URL(request.url);
   const forceShow = searchParams.get('force') === 'true';
   
@@ -141,6 +145,8 @@ export async function GET(request: NextRequest) {
 
 // Only allow GET requests
 export async function POST() {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return NextResponse.json(
     { error: 'Method not allowed' },
     { status: 405 }

--- a/src/app/api/files/[id]/analytics/route.ts
+++ b/src/app/api/files/[id]/analytics/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileDatabase } from '@/lib/database/files';
 import { downloadTrackingDatabase } from '@/lib/database/download-tracking';
 import { z } from 'zod';
@@ -17,6 +18,8 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { id } = await params;
     

--- a/src/app/api/files/[id]/download/route.ts
+++ b/src/app/api/files/[id]/download/route.ts
@@ -1,10 +1,10 @@
+import { headers, cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileManagementService } from '@/lib/services/file-management-service';
 import { downloadTrackingDatabase } from '@/lib/database/download-tracking';
 import { fileDownloadRateLimit } from '@/lib/security/file-rate-limit';
 import { getCorsHeadersForPublicEndpoint } from '@/lib/security/cors';
-import { headers } from 'next/headers';
 import { z } from 'zod';
 
 // Validation schema for download options
@@ -19,6 +19,8 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   const startTime = Date.now();
   let downloadId: string | null = null;
 
@@ -283,6 +285,8 @@ export async function POST(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const params = await context.params;
     const body = await request.json();

--- a/src/app/api/files/[id]/optimize/route.ts
+++ b/src/app/api/files/[id]/optimize/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileDatabase } from '@/lib/database/files';
 import { fileOptimizationService } from '@/lib/services/file-optimization';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -21,6 +22,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { id } = await params;
     
@@ -225,6 +228,8 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { id } = await params;
     

--- a/src/app/api/files/[id]/share/route.ts
+++ b/src/app/api/files/[id]/share/route.ts
@@ -1,7 +1,8 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { fileManagementService } from '@/lib/services/file-management-service';
 import { authMiddleware } from '@/lib/auth/middleware';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 
 interface RouteParams {
   params: Promise<{
@@ -13,6 +14,8 @@ interface RouteParams {
  * POST /api/files/[id]/share - Share a file with another user
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const paramsData = await params;
     
@@ -91,6 +94,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
  * GET /api/files/[id]/share - Get file sharing information
  */
 export async function GET(request: NextRequest, { params }: RouteParams) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Authenticate user
     const authResult = await authMiddleware(request);
@@ -152,6 +157,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
  * DELETE /api/files/[id]/share - Remove file sharing (revoke access)
  */
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Authenticate user
     const authResult = await authMiddleware(request);

--- a/src/app/api/files/[id]/shares/temporary/route.ts
+++ b/src/app/api/files/[id]/shares/temporary/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { temporarySharesDatabase } from '@/lib/database/temporary-shares';
 import { fileDatabase } from '@/lib/database/files';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -26,6 +27,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -137,6 +141,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Get authenticated user
     const supabase = await createClient();

--- a/src/app/api/files/[id]/versions/[versionId]/route.ts
+++ b/src/app/api/files/[id]/versions/[versionId]/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileVersionsDatabase } from '@/lib/database/file-versions';
 import { fileDatabase } from '@/lib/database/files';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -17,6 +18,8 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; versionId: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { id, versionId } = await params;
     
@@ -100,6 +103,8 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; versionId: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { id, versionId } = await params;
     
@@ -199,6 +204,8 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; versionId: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { id, versionId } = await params;
     

--- a/src/app/api/files/[id]/versions/compare/route.ts
+++ b/src/app/api/files/[id]/versions/compare/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileVersionsDatabase } from '@/lib/database/file-versions';
 import { fileDatabase } from '@/lib/database/files';
 import { z } from 'zod';
@@ -15,6 +16,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Get authenticated user
     const supabase = await createClient();
@@ -127,6 +131,8 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const { searchParams } = new URL(request.url);
     const versionA = parseInt(searchParams.get('version_a') || '');

--- a/src/app/api/files/[id]/versions/rollback/route.ts
+++ b/src/app/api/files/[id]/versions/rollback/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileVersionsDatabase } from '@/lib/database/file-versions';
 import { fileDatabase } from '@/lib/database/files';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -16,6 +17,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/files/[id]/versions/route.ts
+++ b/src/app/api/files/[id]/versions/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileVersionsDatabase } from '@/lib/database/file-versions';
 import { fileDatabase } from '@/lib/database/files';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -22,6 +23,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Get authenticated user
     const supabase = await createClient();
@@ -104,6 +108,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/files/share/bulk/route.ts
+++ b/src/app/api/files/share/bulk/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileManagementService } from '@/lib/services/file-management-service';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
 import { z } from 'zod';
@@ -67,6 +68,8 @@ async function checkCoachClientRelationship(
  * POST /api/files/share/bulk - Share multiple files with multiple users
  */
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -266,6 +269,8 @@ export async function POST(request: NextRequest) {
  * DELETE /api/files/share/bulk - Bulk revoke file shares
  */
 export async function DELETE(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -408,6 +413,8 @@ export async function DELETE(request: NextRequest) {
  * PUT /api/files/share/bulk - Bulk update file share permissions
  */
 export async function PUT(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/files/share/route.ts
+++ b/src/app/api/files/share/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileManagementService } from '@/lib/services/file-management-service';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
 import { z } from 'zod';
@@ -67,6 +68,8 @@ async function checkCoachClientRelationship(
 
 // POST /api/files/share - Share files with other users
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -231,6 +234,8 @@ export async function POST(request: NextRequest) {
 
 // GET /api/files/share - Get file shares (shared by user or shared with user)
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Get authenticated user
     const supabase = await createClient();
@@ -377,6 +382,8 @@ export async function GET(request: NextRequest) {
 
 // DELETE /api/files/share - Revoke file sharing access
 export async function DELETE(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/files/shares/temporary/[shareId]/route.ts
+++ b/src/app/api/files/shares/temporary/[shareId]/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { temporarySharesDatabase } from '@/lib/database/temporary-shares';
 import { fileDatabase } from '@/lib/database/files';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -27,6 +28,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ shareId: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { shareId } = await params;
   try {
     // Get authenticated user
     const supabase = await createClient();
@@ -110,6 +114,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ shareId: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { shareId } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -226,6 +233,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ shareId: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { shareId } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/files/shares/temporary/route.ts
+++ b/src/app/api/files/shares/temporary/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { temporarySharesDatabase } from '@/lib/database/temporary-shares';
 import { fileManagementService } from '@/lib/services/file-management-service';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -41,6 +42,8 @@ const listTemporarySharesSchema = z.object({
  * POST /api/files/shares/temporary - Create a new temporary share
  */
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -202,6 +205,8 @@ export async function POST(request: NextRequest) {
  * GET /api/files/shares/temporary - List user's temporary shares
  */
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Get authenticated user
     const supabase = await createClient();
@@ -365,6 +370,8 @@ export async function GET(request: NextRequest) {
  * DELETE /api/files/shares/temporary - Bulk delete temporary shares
  */
 export async function DELETE(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/files/upload/chunked/route.ts
+++ b/src/app/api/files/upload/chunked/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileService } from '@/lib/services/file-service';
 import { fileUploadRateLimit } from '@/lib/security/file-rate-limit';
 import { z } from 'zod';
@@ -61,6 +62,8 @@ setInterval(() => {
  * POST /api/files/upload/chunked - Initialize chunked upload or upload chunk
  */
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileUploadRateLimit(request);
@@ -477,6 +480,8 @@ async function handleChunkedUploadAbort(request: NextRequest, userId: string) {
  * GET /api/files/upload/chunked - Get upload status
  */
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Get authenticated user
     const supabase = await createClient();

--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileService } from '@/lib/services/file-service';
 import { ApiError } from '@/lib/api/errors';
 import { fileUploadRateLimit } from '@/lib/security/file-rate-limit';
@@ -55,6 +56,8 @@ const FILE_TYPE_CONFIGS = {
 };
 
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Apply rate limiting
     const rateLimitResult = await fileUploadRateLimit(request);

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,10 +1,13 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { compose, withRateLimit } from '@/lib/api';
 import { createPublicCorsResponse } from '@/lib/security/cors';
 
 async function baseHealthHandler(request: NextRequest) {
   const start = Date.now();
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   try {
     // Perform comprehensive health checks
@@ -106,6 +109,8 @@ export const HEAD = compose(baseHeadHandler, withRateLimit());
 
 // OPTIONS /api/health - Handle CORS preflight
 export async function OPTIONS(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return createPublicCorsResponse();
 }
 

--- a/src/app/api/monitoring/business-metrics/route.ts
+++ b/src/app/api/monitoring/business-metrics/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { rateLimit } from '@/lib/security/rate-limit';
 import { trackBusinessMetric } from '@/lib/monitoring/sentry';
 
@@ -51,11 +52,15 @@ const rateLimitedMetrics = rateLimit(100, 60000)( // 100 requests per minute
 
 // GET /api/monitoring/business-metrics - Retrieve business metrics
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return rateLimitedMetrics(request);
 }
 
 // POST /api/monitoring/business-metrics - Submit metrics data
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return rateLimitedMetrics(request);
 }
 

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
 import { 
   createSuccessResponse, 
@@ -7,6 +8,7 @@ import {
 } from '@/lib/api/utils';
 import { NotificationService } from '@/lib/database/notifications';
 import { createCorsResponse, applyCorsHeaders } from '@/lib/security/cors';
+import { setSupabaseCookieStore } from '@/lib/supabase/server';
 
 interface RouteParams {
   params: Promise<{
@@ -17,6 +19,8 @@ interface RouteParams {
 // POST /api/notifications/[id]/read - Mark notification as read
 export const POST = withErrorHandling(async (request: NextRequest, { params }: RouteParams) => {
   const { id } = await params;
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   // Authenticate user
   const authHeader = request.headers.get('authorization');
@@ -73,5 +77,7 @@ export const POST = withErrorHandling(async (request: NextRequest, { params }: R
 
 // OPTIONS /api/notifications/[id]/read - Handle CORS preflight
 export async function OPTIONS(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return createCorsResponse(request);
 }

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
 import { compose, withAuth, withRateLimit } from '@/lib/api';
 import { 
@@ -8,6 +9,7 @@ import {
 } from '@/lib/api/utils';
 import { NotificationService } from '@/lib/database/notifications';
 import { createCorsResponse, applyCorsHeaders } from '@/lib/security/cors';
+import { setSupabaseCookieStore } from '@/lib/supabase/server';
 
 interface RouteParams {
   params: Promise<{
@@ -18,6 +20,8 @@ interface RouteParams {
 // GET /api/notifications/[id] - Get specific notification
 export const GET = compose(withErrorHandling(async (request: NextRequest, { params }: RouteParams) => {
   const { id } = await params;
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   // Authenticate user
   const authHeader = request.headers.get('authorization');
@@ -75,6 +79,8 @@ export const GET = compose(withErrorHandling(async (request: NextRequest, { para
 // DELETE /api/notifications/[id] - Delete notification
 export const DELETE = compose(withErrorHandling(async (request: NextRequest, { params }: RouteParams) => {
   const { id } = await params;
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   // Authenticate user
   const authHeader = request.headers.get('authorization');
@@ -131,5 +137,7 @@ export const DELETE = compose(withErrorHandling(async (request: NextRequest, { p
 
 // OPTIONS /api/notifications/[id] - Handle CORS preflight
 export async function OPTIONS(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return createCorsResponse(request);
 }

--- a/src/app/api/notifications/mark-all-read/route.ts
+++ b/src/app/api/notifications/mark-all-read/route.ts
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
 import { 
   createSuccessResponse, 
@@ -7,9 +8,12 @@ import {
 } from '@/lib/api/utils';
 import { NotificationService } from '@/lib/database/notifications';
 import { createCorsResponse, applyCorsHeaders } from '@/lib/security/cors';
+import { setSupabaseCookieStore } from '@/lib/supabase/server';
 
 // POST /api/notifications/mark-all-read - Mark all notifications as read
 export const POST = withErrorHandling(async (request: NextRequest) => {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   // Authenticate user
   const authHeader = request.headers.get('authorization');
   if (!authHeader) {
@@ -64,5 +68,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
 // OPTIONS /api/notifications/mark-all-read - Handle CORS preflight
 export async function OPTIONS(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return createCorsResponse(request);
 }

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -1,4 +1,5 @@
-import { createClient } from '@/lib/supabase/server'
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server'
+import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -40,8 +41,10 @@ const notificationPreferencesSchema = z.object({
 })
 
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
-    const supabase = createClient()
+    const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     
     if (authError || !user) {
@@ -122,8 +125,10 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
-    const supabase = createClient()
+    const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     
     if (authError || !user) {

--- a/src/app/api/sessions/[id]/files/route.ts
+++ b/src/app/api/sessions/[id]/files/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { fileDatabase } from '@/lib/database/files';
 import { sessionFilesDatabase } from '@/lib/database/session-files';
 import { fileModificationRateLimit } from '@/lib/security/file-rate-limit';
@@ -77,6 +78,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Get authenticated user
     const supabase = await createClient();
@@ -163,6 +167,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -296,6 +303,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);
@@ -420,6 +430,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Apply rate limiting
     const rateLimitResult = await fileModificationRateLimit(request);

--- a/src/app/api/share/[token]/route.ts
+++ b/src/app/api/share/[token]/route.ts
@@ -1,13 +1,16 @@
+import { headers, cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { temporarySharesDatabase } from '@/lib/database/temporary-shares';
-import { headers } from 'next/headers';
 
 // GET /api/share/[token] - Access shared file (API endpoint for programmatic access)
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ token: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { token } = await params;
   try {
     const { searchParams } = new URL(request.url);
     const password = searchParams.get('password');
@@ -154,6 +157,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ token: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { token } = await params;
   try {
     const body = await request.json();
     const { password, download } = body;

--- a/src/app/api/shares/cleanup/route.ts
+++ b/src/app/api/shares/cleanup/route.ts
@@ -1,11 +1,13 @@
+import { headers, cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { temporarySharesDatabase } from '@/lib/database/temporary-shares';
-import { headers } from 'next/headers';
 
 // POST /api/shares/cleanup - Cleanup expired temporary shares
 // This endpoint should be called by a cron job or scheduled task
 export async function POST(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Verify the request is authorized (cron job or admin)
     const headersList = await headers();
@@ -83,6 +85,8 @@ export async function POST(request: NextRequest) {
 
 // GET /api/shares/cleanup - Get cleanup statistics (admin only)
 export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     // Authenticate user
     const supabase = await createClient();

--- a/src/app/api/users/[id]/download-history/route.ts
+++ b/src/app/api/users/[id]/download-history/route.ts
@@ -1,5 +1,6 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { downloadTrackingDatabase } from '@/lib/database/download-tracking';
 import { z } from 'zod';
 
@@ -14,6 +15,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
+  const { id } = await params;
   try {
     // Get authenticated user
     const supabase = await createClient();

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
 import { 
   createSuccessResponse, 
@@ -9,6 +10,7 @@ import {
 import { uuidSchema, updateUserSchema } from '@/lib/api/validation';
 import { UserService } from '@/lib/database/users';
 import { createCorsResponse, applyCorsHeaders } from '@/lib/security/cors';
+import { setSupabaseCookieStore } from '@/lib/supabase/server';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -17,6 +19,8 @@ interface RouteParams {
 // GET /api/users/[id] - Get user by ID
 export const GET = withErrorHandling(async (request: NextRequest, { params }: RouteParams) => {
   const { id } = await params;
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   // Authenticate user
   const authHeader = request.headers.get('authorization');
@@ -88,6 +92,8 @@ export const GET = withErrorHandling(async (request: NextRequest, { params }: Ro
 // PUT /api/users/[id] - Update user
 export const PUT = withErrorHandling(async (request: NextRequest, { params }: RouteParams) => {
   const { id } = await params;
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   // Authenticate user
   const authHeader = request.headers.get('authorization');
@@ -174,6 +180,8 @@ export const PUT = withErrorHandling(async (request: NextRequest, { params }: Ro
 // DELETE /api/users/[id] - Delete user (Admin only)
 export const DELETE = withErrorHandling(async (request: NextRequest, { params }: RouteParams) => {
   const { id } = await params;
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   
   // Authenticate user
   const authHeader = request.headers.get('authorization');
@@ -251,5 +259,7 @@ export const DELETE = withErrorHandling(async (request: NextRequest, { params }:
 
 // OPTIONS /api/users/[id] - Handle CORS preflight
 export async function OPTIONS(request: NextRequest) {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   return createCorsResponse(request);
 }

--- a/src/app/api/widgets/achievements/route.ts
+++ b/src/app/api/widgets/achievements/route.ts
@@ -1,6 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUser } from '@/lib/auth/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { ApiResponse } from '@/lib/api/types';
 
 export interface Achievement {
@@ -24,6 +25,8 @@ export interface AchievementsResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<ApiResponse<AchievementsResponse>>> {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const user = await getServerUser();
     if (!user) {

--- a/src/app/api/widgets/analytics/route.ts
+++ b/src/app/api/widgets/analytics/route.ts
@@ -1,6 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUser } from '@/lib/auth/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { ApiResponse } from '@/lib/api/types';
 
 export interface ClientProgressData {
@@ -52,6 +53,8 @@ export interface AnalyticsResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<ApiResponse<AnalyticsResponse>>> {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const user = await getServerUser();
     if (!user) {

--- a/src/app/api/widgets/feedback/route.ts
+++ b/src/app/api/widgets/feedback/route.ts
@@ -1,6 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUser } from '@/lib/auth/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { ApiResponse } from '@/lib/api/types';
 
 export interface FeedbackWidget {
@@ -27,6 +28,8 @@ export interface FeedbackResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<ApiResponse<FeedbackResponse>>> {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const user = await getServerUser();
     if (!user) {

--- a/src/app/api/widgets/goals/route.ts
+++ b/src/app/api/widgets/goals/route.ts
@@ -1,6 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUser } from '@/lib/auth/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { ApiResponse } from '@/lib/api/types';
 
 export interface GoalData {
@@ -23,6 +24,8 @@ export interface GoalsResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<ApiResponse<GoalsResponse>>> {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const user = await getServerUser();
     if (!user) {

--- a/src/app/api/widgets/progress/route.ts
+++ b/src/app/api/widgets/progress/route.ts
@@ -1,6 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUser } from '@/lib/auth/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { ApiResponse } from '@/lib/api/types';
 
 export interface Milestone {
@@ -31,6 +32,8 @@ export interface ProgressResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<ApiResponse<ProgressResponse>>> {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const user = await getServerUser();
     if (!user) {

--- a/src/app/api/widgets/sessions/route.ts
+++ b/src/app/api/widgets/sessions/route.ts
@@ -1,6 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUser } from '@/lib/auth/auth';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, setSupabaseCookieStore } from '@/lib/supabase/server';
 import { ApiResponse } from '@/lib/api/types';
 import { getCachedData, CacheKeys, CacheTTL } from '@/lib/performance/cache';
 
@@ -29,6 +30,8 @@ export interface SessionsResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<ApiResponse<SessionsResponse>>> {
+  const cookieStore = cookies();
+  setSupabaseCookieStore(cookieStore);
   try {
     const user = await getServerUser();
     if (!user) {


### PR DESCRIPTION
## Summary
- add AsyncLocalStorage-backed cookie context helpers in `src/lib/supabase/server.ts` so route handlers can provide request cookies without importing `next/headers`
- update API routes that use `createClient` to initialize the cookie context with `setSupabaseCookieStore(cookies())` before Supabase access
- ensure server routes awaiting `createClient()` and retain request parameter destructuring where necessary for Supabase operations

## Testing
- `npm run lint -- --dir src/app/api` *(fails: existing lint/type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de738879a8832084c28f0d62551abb