### PR TITLE
Improve accessibility for buttons and language switcher

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -116,7 +116,7 @@ export default async function HomePage({ params }: HomePageProps) {
       >
         <div className="flex flex-col items-center gap-6">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-            <Link href={hero.primaryHref as '/auth/signin'} locale={locale} className="inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-light tracking-wide bg-orange-600 text-white hover:bg-orange-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal h-13 px-8 py-3 text-base min-w-[200px]">
+            <Link href={hero.primaryHref as '/auth/signin'} locale={locale} className="inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-light tracking-wide bg-terracotta-700 text-white hover:bg-terracotta-800 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal h-13 px-8 py-3 text-base min-w-[200px]">
               {hero.primaryCta}
             </Link>
             <Link href={hero.secondaryHref as '/auth/signup'} locale={locale} className="inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-light tracking-wide bg-neutral-900 text-white hover:bg-neutral-800 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal h-13 px-8 py-3 text-base min-w-[200px]">

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -2,12 +2,14 @@
 
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import { Label } from '@/components/ui/label';
 import { 
   Download, 
   Eye, 
@@ -50,6 +52,7 @@ interface ShareAccessValidation {
 export default function SharePage() {
   const params = useParams();
   const token = params.token as string;
+  const t = useTranslations('share');
   
   const [loading, setLoading] = useState(true);
   const [downloading, setDownloading] = useState(false);
@@ -280,13 +283,17 @@ export default function SharePage() {
                 <p className="text-gray-600 mb-4">
                   This shared file is password protected. Please enter the password to access it.
                 </p>
-                <Input
-                  type="password"
-                  placeholder="Enter password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full"
-                />
+                <div className="space-y-2">
+                  <Label htmlFor="share-password">{t('passwordLabel')}</Label>
+                  <Input
+                    id="share-password"
+                    type="password"
+                    placeholder={t('passwordPlaceholder')}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full"
+                  />
+                </div>
                 <Button type="submit" className="w-full" disabled={!password.trim()}>
                   Access File
                 </Button>

--- a/src/components/landing/persona-showcase.tsx
+++ b/src/components/landing/persona-showcase.tsx
@@ -110,7 +110,7 @@ export function PersonaShowcase() {
                     </ul>
 
                     <div className="mt-8 flex flex-wrap gap-3">
-                      <Link href={personaRouteMap[persona.id]} locale={locale} className="inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-light tracking-wide bg-orange-600 text-white hover:bg-orange-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal h-13 px-8 py-3 text-base gap-2">
+                      <Link href={personaRouteMap[persona.id]} locale={locale} className="inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-light tracking-wide bg-terracotta-700 text-white hover:bg-terracotta-800 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal h-13 px-8 py-3 text-base gap-2">
                         {persona.ctaLabel}
                         <ArrowRight className="h-4 w-4" aria-hidden="true" />
                       </Link>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,11 +9,11 @@ const buttonVariants = cva(
     variants: {
       variant: {
         // Primary - Soft Teal (Satya Method primary action)
-        default: 'bg-teal-400 text-white hover:bg-teal-500 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal',
+        default: 'bg-teal-700 text-white hover:bg-teal-800 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal',
         // Secondary - Warm neutrals
         secondary: 'bg-sand-200 text-sand-700 hover:bg-sand-300 shadow-sm hover:shadow-md hover:-translate-y-0.5',
         // Destructive - Warm Terracotta
-        destructive: 'bg-terracotta-500 text-white hover:bg-terracotta-600 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal',
+        destructive: 'bg-terracotta-700 text-white hover:bg-terracotta-800 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal',
         // Success - Moss Green
         success: 'bg-moss-500 text-white hover:bg-moss-600 shadow-md hover:shadow-lg hover:-translate-y-0.5 font-normal',
         // Outline - Grounded border

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { 
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -8,13 +8,14 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
-import { 
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Globe, Languages, Check } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useLanguageSwitcher } from '@/hooks/use-language-switcher';
 
 interface LanguageSwitcherProps {
@@ -25,7 +26,7 @@ interface LanguageSwitcherProps {
   className?: string;
 }
 
-export function LanguageSwitcher({ 
+export function LanguageSwitcher({
   variant = 'dropdown',
   showFlag = true,
   showNativeName = false,
@@ -33,6 +34,7 @@ export function LanguageSwitcher({
   className = ''
 }: LanguageSwitcherProps) {
   const { currentLocale, currentLanguage, availableLanguages, switchLanguage } = useLanguageSwitcher();
+  const t = useTranslations('common');
 
   if (variant === 'select') {
     return (
@@ -88,8 +90,10 @@ export function LanguageSwitcher({
           variant="ghost"
           size={size}
           className={`flex items-center rtl:space-x-reverse space-x-2 ${className}`}
+          aria-label={t('changeLanguage')}
         >
-          <Languages className="h-4 w-4" />
+          <Languages aria-hidden="true" className="h-4 w-4" />
+          <span className="sr-only">{t('changeLanguage')}</span>
           {showFlag && <span>{currentLanguage?.flag}</span>}
           <span className="hidden sm:inline">
             {showNativeName ? currentLanguage?.nativeName : currentLanguage?.name}
@@ -125,6 +129,7 @@ export function LanguageSwitcher({
 // Compact version for mobile or space-constrained areas
 export function CompactLanguageSwitcher({ className = '' }: { className?: string }) {
   const { currentLocale, availableLanguages, switchLanguage } = useLanguageSwitcher();
+  const t = useTranslations('common');
 
   return (
     <DropdownMenu>
@@ -133,8 +138,11 @@ export function CompactLanguageSwitcher({ className = '' }: { className?: string
           variant="ghost"
           size="sm"
           className={`w-10 h-10 p-0 ${className}`}
+          aria-label={t('changeLanguage')}
+          iconOnly
         >
-          <Globe className="h-4 w-4" />
+          <Globe aria-hidden="true" className="h-4 w-4" />
+          <span className="sr-only">{t('changeLanguage')}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-32">

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -9,6 +9,7 @@
     "search": "Search",
     "filter": "Filter",
     "sort": "Sort",
+    "changeLanguage": "Change language",
     "actions": "Actions",
     "yes": "Yes",
     "no": "No",
@@ -965,6 +966,10 @@
       "storage": "Storage",
       "serviceStatus": "Service Status"
     }
+  },
+  "share": {
+    "passwordLabel": "Password",
+    "passwordPlaceholder": "Enter password"
   },
   "notFound": {
     "title": "Page Not Found",

--- a/src/messages/he.json
+++ b/src/messages/he.json
@@ -9,6 +9,7 @@
     "search": "חפש",
     "filter": "סנן",
     "sort": "מיון",
+    "changeLanguage": "שנה שפה",
     "actions": "פעולות",
     "yes": "כן",
     "no": "לא",
@@ -1199,6 +1200,10 @@
       "storage": "אחסון",
       "serviceStatus": "סטטוס שירותים"
     }
+  },
+  "share": {
+    "passwordLabel": "סיסמה",
+    "passwordPlaceholder": "הקלד סיסמה"
   },
   "notFound": {
     "title": "הדף לא נמצא",


### PR DESCRIPTION
## Summary
- darken the primary and destructive button variants to meet contrast expectations and update landing CTA buttons that reused the legacy colors
- add a programmatic password label on the shared file access flow with locale-aware messaging
- provide accessible names for the language switcher’s icon buttons and add the required translations

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68df4d4531548320b5dc3e3b78039270