### PR TITLE
Fix onboarding completion caching for coach and client flows

### DIFF
--- a/src/app/api/onboarding/client/route.ts
+++ b/src/app/api/onboarding/client/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { createAuthService } from '@/lib/auth/auth';
+import { createAdminClient } from '@/lib/supabase/server';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  HTTP_STATUS,
+  rateLimit,
+  validateRequestBody,
+  withErrorHandling,
+} from '@/lib/api/utils';
+
+const clientOnboardingSchema = z.object({
+  step: z.number().int().min(1).max(3),
+  goals: z.array(z.string().min(2).max(120)).min(1).max(10),
+  focusAreas: z.array(z.string().min(2).max(120)).min(1).max(10),
+  supportPreferences: z.array(z.string().min(2).max(120)).max(10).optional(),
+  preferredCommunication: z.enum(['video', 'phone', 'in_person', 'hybrid']),
+  sessionFrequency: z.enum(['weekly', 'biweekly', 'monthly', 'flexible']),
+  timezone: z.string().min(2).max(64).optional(),
+  notes: z.string().max(1200).optional(),
+});
+
+const rateLimitedHandler = rateLimit(10, 60_000);
+
+export const GET = withErrorHandling(async () => {
+  const authService = await createAuthService(true);
+  const user = await authService.getCurrentUser();
+
+  if (!user) {
+    return createErrorResponse('Not authenticated', HTTP_STATUS.UNAUTHORIZED);
+  }
+
+  if (user.role !== 'client') {
+    return createErrorResponse('Client access required', HTTP_STATUS.FORBIDDEN);
+  }
+
+  const onboardingData = (user.onboardingData as Record<string, unknown> | undefined) ?? {};
+  const clientData = (onboardingData.client as Record<string, unknown> | undefined) ?? {};
+
+  return createSuccessResponse({
+    preferences: {
+      goals: Array.isArray(clientData.goals) ? (clientData.goals as string[]) : [],
+      focusAreas: Array.isArray(clientData.focusAreas) ? (clientData.focusAreas as string[]) : [],
+      supportPreferences: Array.isArray(clientData.supportPreferences)
+        ? (clientData.supportPreferences as string[])
+        : [],
+      preferredCommunication:
+        typeof clientData.preferredCommunication === 'string'
+          ? (clientData.preferredCommunication as string)
+          : 'video',
+      sessionFrequency:
+        typeof clientData.sessionFrequency === 'string'
+          ? (clientData.sessionFrequency as string)
+          : 'weekly',
+      timezone:
+        typeof clientData.timezone === 'string'
+          ? (clientData.timezone as string)
+          : user.timezone ?? 'UTC',
+      notes: typeof clientData.notes === 'string' ? (clientData.notes as string) : '',
+    },
+    onboarding: {
+      status: user.onboardingStatus ?? 'pending',
+      step: user.onboardingStep ?? 0,
+      completedAt: user.onboardingCompletedAt ?? null,
+    },
+  });
+});
+
+export const PUT = withErrorHandling(
+  rateLimitedHandler(async (request: NextRequest) => {
+    const authService = await createAuthService(true);
+    const user = await authService.getCurrentUser();
+
+    if (!user) {
+      return createErrorResponse('Not authenticated', HTTP_STATUS.UNAUTHORIZED);
+    }
+
+    if (user.role !== 'client') {
+      return createErrorResponse('Client access required', HTTP_STATUS.FORBIDDEN);
+    }
+
+    const payload = await request.json();
+    const validation = validateRequestBody(clientOnboardingSchema, payload, {
+      sanitize: true,
+      maxSize: 12 * 1024,
+    });
+
+    if (!validation.success) {
+      return createErrorResponse(validation.error, HTTP_STATUS.BAD_REQUEST);
+    }
+
+    const data = validation.data;
+    const admin = createAdminClient();
+
+    const existingData = (user.onboardingData as Record<string, unknown> | undefined) ?? {};
+
+    const updatedOnboardingData = {
+      ...existingData,
+      client: {
+        goals: data.goals,
+        focusAreas: data.focusAreas,
+        supportPreferences: data.supportPreferences ?? [],
+        preferredCommunication: data.preferredCommunication,
+        sessionFrequency: data.sessionFrequency,
+        timezone: data.timezone ?? user.timezone ?? 'UTC',
+        notes: data.notes ?? '',
+      },
+    };
+
+    const completedAt = new Date().toISOString();
+    const nextStep = Math.max(data.step ?? 3, 3);
+
+    const { error: userUpdateError } = await admin
+      .from('users')
+      .update({
+        timezone: data.timezone ?? user.timezone ?? 'UTC',
+        onboarding_status: 'completed',
+        onboarding_step: nextStep,
+        onboarding_completed_at: completedAt,
+        onboarding_data: updatedOnboardingData,
+      })
+      .eq('id', user.id);
+
+    if (userUpdateError) {
+      return createErrorResponse('Failed to save onboarding preferences', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    }
+
+    const refreshedUser = await authService.getCurrentUser({ forceRefresh: true });
+
+    return createSuccessResponse(
+      {
+        user: {
+          onboardingStatus: (refreshedUser?.onboardingStatus ?? 'completed') as const,
+          onboardingStep: refreshedUser?.onboardingStep ?? nextStep,
+          onboardingCompletedAt: refreshedUser?.onboardingCompletedAt ?? completedAt,
+          timezone: refreshedUser?.timezone ?? data.timezone ?? user.timezone ?? 'UTC',
+          onboardingData: refreshedUser?.onboardingData ?? updatedOnboardingData,
+        },
+      },
+      'Client onboarding completed successfully'
+    );
+  })
+);

--- a/src/app/api/onboarding/coach/route.ts
+++ b/src/app/api/onboarding/coach/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { createAuthService } from '@/lib/auth/auth';
+import { createAdminClient } from '@/lib/supabase/server';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  HTTP_STATUS,
+  rateLimit,
+  validateRequestBody,
+  withErrorHandling,
+} from '@/lib/api/utils';
+
+const availabilitySchema = z.object({
+  dayOfWeek: z.number().int().min(0).max(6),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/),
+  endTime: z.string().regex(/^\d{2}:\d{2}$/),
+});
+
+const coachOnboardingSchema = z.object({
+  step: z.number().int().min(1).max(5),
+  title: z.string().min(2).max(120).optional(),
+  bio: z.string().min(20).max(1200),
+  experienceYears: z.number().int().min(0).max(60),
+  specialties: z.array(z.string().min(2).max(80)).min(1).max(12),
+  credentials: z.array(z.string().min(2).max(120)).max(10).optional(),
+  languages: z.array(z.string().min(2).max(32)).min(1).max(5),
+  timezone: z.string().min(2).max(64),
+  hourlyRate: z.number().min(0).max(2000),
+  currency: z.string().min(3).max(3),
+  approach: z.string().min(20).max(1200),
+  location: z.string().min(2).max(120),
+  availability: z.array(availabilitySchema).min(1).max(21),
+});
+
+const rateLimitedHandler = rateLimit(10, 60_000);
+
+export const GET = withErrorHandling(async () => {
+  const authService = await createAuthService(true);
+  const user = await authService.getCurrentUser();
+
+  if (!user) {
+    return createErrorResponse('Not authenticated', HTTP_STATUS.UNAUTHORIZED);
+  }
+
+  if (user.role !== 'coach') {
+    return createErrorResponse('Coach access required', HTTP_STATUS.FORBIDDEN);
+  }
+
+  const admin = createAdminClient();
+
+  const { data: profile } = await admin
+    .from('coach_profiles')
+    .select(
+      'title, bio, experience_years, specialties, credentials, languages, timezone, hourly_rate, currency, approach, location'
+    )
+    .eq('coach_id', user.id)
+    .maybeSingle();
+
+  const { data: availabilityRows } = await admin
+    .from('coach_availability')
+    .select('day_of_week, start_time, end_time, is_available')
+    .eq('coach_id', user.id)
+    .order('day_of_week', { ascending: true });
+
+  const availability = (availabilityRows || [])
+    .filter((row: any) => row.is_available !== false)
+    .map((row: any) => ({
+      dayOfWeek: Number(row.day_of_week) || 0,
+      startTime: typeof row.start_time === 'string' ? row.start_time.slice(0, 5) : '09:00',
+      endTime: typeof row.end_time === 'string' ? row.end_time.slice(0, 5) : '17:00',
+    }));
+
+  return createSuccessResponse({
+    profile: {
+      title: profile?.title ?? 'Professional Coach',
+      bio: profile?.bio ?? '',
+      experienceYears: profile?.experience_years ?? 0,
+      specialties: Array.isArray(profile?.specialties) ? profile?.specialties : [],
+      credentials: Array.isArray(profile?.credentials) ? profile.credentials : [],
+      languages: Array.isArray(profile?.languages) && profile.languages.length > 0
+        ? profile.languages
+        : [user.language],
+      timezone: profile?.timezone ?? user.timezone ?? 'UTC',
+      hourlyRate: typeof profile?.hourly_rate === 'number' ? Number(profile.hourly_rate) : 100,
+      currency: profile?.currency ?? 'USD',
+      approach: profile?.approach ?? '',
+      location: profile?.location ?? '',
+    },
+    availability,
+    onboarding: {
+      status: user.onboardingStatus ?? 'pending',
+      step: user.onboardingStep ?? 0,
+      completedAt: user.onboardingCompletedAt ?? null,
+    },
+  });
+});
+
+export const PUT = withErrorHandling(
+  rateLimitedHandler(async (request: NextRequest) => {
+    const authService = await createAuthService(true);
+    const user = await authService.getCurrentUser();
+
+    if (!user) {
+      return createErrorResponse('Not authenticated', HTTP_STATUS.UNAUTHORIZED);
+    }
+
+    if (user.role !== 'coach') {
+      return createErrorResponse('Coach access required', HTTP_STATUS.FORBIDDEN);
+    }
+
+    const payload = await request.json();
+    const validation = validateRequestBody(coachOnboardingSchema, payload, {
+      sanitize: true,
+      maxSize: 16 * 1024,
+    });
+
+    if (!validation.success) {
+      return createErrorResponse(validation.error, HTTP_STATUS.BAD_REQUEST);
+    }
+
+    const data = validation.data;
+    const admin = createAdminClient();
+
+    const availability = data.availability.map((slot) => ({
+      coach_id: user.id,
+      day_of_week: slot.dayOfWeek,
+      start_time: slot.startTime,
+      end_time: slot.endTime,
+      is_available: true,
+      timezone: data.timezone,
+    }));
+
+    const { error: profileError } = await admin.from('coach_profiles').upsert(
+      {
+        coach_id: user.id,
+        title: data.title ?? 'Professional Coach',
+        bio: data.bio,
+        experience_years: data.experienceYears,
+        specialties: data.specialties,
+        credentials: data.credentials ?? [],
+        languages: data.languages,
+        timezone: data.timezone,
+        hourly_rate: data.hourlyRate,
+        currency: data.currency,
+        approach: data.approach,
+        location: data.location,
+      },
+      { onConflict: 'coach_id' }
+    );
+
+    if (profileError) {
+      return createErrorResponse('Failed to update coach profile', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    }
+
+    await admin.from('coach_availability').delete().eq('coach_id', user.id);
+
+    if (availability.length > 0) {
+      const { error: availabilityError } = await admin.from('coach_availability').insert(availability);
+      if (availabilityError) {
+        return createErrorResponse('Failed to update availability', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+    }
+
+    const completedAt = new Date().toISOString();
+    const nextStep = Math.max(data.step ?? 5, 5);
+
+    const existingOnboardingData =
+      (user.onboardingData as Record<string, unknown> | null | undefined) ?? {};
+
+    const updatedOnboardingData = {
+      ...existingOnboardingData,
+      coach: {
+        title: data.title ?? 'Professional Coach',
+        bio: data.bio,
+        experienceYears: data.experienceYears,
+        specialties: data.specialties,
+        credentials: data.credentials ?? [],
+        languages: data.languages,
+        timezone: data.timezone,
+        hourlyRate: data.hourlyRate,
+        currency: data.currency,
+        approach: data.approach,
+        location: data.location,
+        availability: data.availability,
+      },
+    };
+
+    const { error: userUpdateError } = await admin
+      .from('users')
+      .update({
+        timezone: data.timezone,
+        onboarding_status: 'completed',
+        onboarding_step: nextStep,
+        onboarding_completed_at: completedAt,
+        onboarding_data: updatedOnboardingData,
+      })
+      .eq('id', user.id);
+
+    if (userUpdateError) {
+      return createErrorResponse('Failed to finalize onboarding', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    }
+
+    const refreshedUser = await authService.getCurrentUser({ forceRefresh: true });
+
+    return createSuccessResponse(
+      {
+        user: {
+          onboardingStatus: (refreshedUser?.onboardingStatus ?? 'completed') as const,
+          onboardingStep: refreshedUser?.onboardingStep ?? nextStep,
+          onboardingCompletedAt: refreshedUser?.onboardingCompletedAt ?? completedAt,
+          timezone: refreshedUser?.timezone ?? data.timezone,
+          onboardingData: refreshedUser?.onboardingData ?? updatedOnboardingData,
+        },
+      },
+      'Coach onboarding completed successfully'
+    );
+  })
+);

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -18,6 +18,10 @@ export interface AuthUser {
   createdAt: string;
   updatedAt: string;
   lastSeenAt?: string;
+  onboardingStatus?: 'pending' | 'in_progress' | 'completed';
+  onboardingStep?: number;
+  onboardingCompletedAt?: string;
+  onboardingData?: Record<string, unknown>;
   // MFA fields
   mfaEnabled?: boolean;
   mfaSetupCompleted?: boolean;
@@ -69,6 +73,10 @@ export class AuthService {
   private userService: ReturnType<typeof createUserService>;
   private userProfileCache = new Map<string, { data: AuthUser; expires: number }>();
 
+  private getUserProfileCacheKey(userId: string): string {
+    return `user_profile_${userId}`;
+  }
+
   private constructor(isServer = true, supabase?: Awaited<ReturnType<typeof createClient>>) {
     // Use singleton clients to prevent multiple GoTrueClient instances
     this.supabase = isServer && supabase ? supabase : clientSupabase;
@@ -90,7 +98,7 @@ export class AuthService {
     }
   }
 
-  private getCachedUserProfile(cacheKey: string, userId: string): AuthUser | null {
+  private getCachedUserProfile(cacheKey: string): AuthUser | null {
     const cached = this.userProfileCache.get(cacheKey);
     if (cached && Date.now() < cached.expires) {
       return cached.data;
@@ -103,6 +111,36 @@ export class AuthService {
       data: user,
       expires: Date.now() + ttlMs
     });
+  }
+
+  public invalidateUserCache(userId: string): void {
+    this.userProfileCache.delete(this.getUserProfileCacheKey(userId));
+  }
+
+  private mapUserProfileToAuthUser(userProfile: User): AuthUser {
+    return {
+      id: userProfile.id,
+      email: userProfile.email,
+      role: userProfile.role,
+      firstName: userProfile.firstName,
+      lastName: userProfile.lastName,
+      phone: userProfile.phone,
+      avatarUrl: userProfile.avatarUrl,
+      timezone: userProfile.timezone,
+      language: userProfile.language,
+      status: userProfile.status,
+      createdAt: userProfile.createdAt,
+      updatedAt: userProfile.updatedAt,
+      lastSeenAt: userProfile.lastSeenAt,
+      onboardingStatus: userProfile.onboardingStatus,
+      onboardingStep: userProfile.onboardingStep,
+      onboardingCompletedAt: userProfile.onboardingCompletedAt,
+      onboardingData: userProfile.onboardingData,
+      mfaEnabled: userProfile.mfaEnabled,
+      mfaSetupCompleted: userProfile.mfaSetupCompleted,
+      mfaVerifiedAt: userProfile.mfaVerifiedAt,
+      rememberDeviceEnabled: userProfile.rememberDeviceEnabled,
+    };
   }
 
   /**
@@ -157,7 +195,7 @@ export class AuthService {
 
         const { data: profile, error: profileError } = await admin
           .from('users')
-          .select('id, email, first_name, last_name, role, language, status, created_at, updated_at, avatar_url, phone, timezone, last_seen_at')
+          .select('id, email, first_name, last_name, role, language, status, created_at, updated_at, avatar_url, phone, timezone, last_seen_at, onboarding_status, onboarding_step, onboarding_completed_at, onboarding_data')
           .eq('id', authData.user.id)
           .single();
 
@@ -177,6 +215,11 @@ export class AuthService {
               createdAt: profile.created_at,
               updatedAt: profile.updated_at,
               lastSeenAt: profile.last_seen_at || undefined,
+              onboardingStatus:
+                (profile.onboarding_status as 'pending' | 'in_progress' | 'completed') || 'pending',
+              onboardingStep: profile.onboarding_step ?? 0,
+              onboardingCompletedAt: profile.onboarding_completed_at || undefined,
+              onboardingData: (profile.onboarding_data as Record<string, unknown>) || {},
             },
             error: null,
           };
@@ -198,6 +241,10 @@ export class AuthService {
           status: 'active',
           createdAt: authData.user.created_at ?? new Date().toISOString(),
           updatedAt: authData.user.updated_at ?? authData.user.created_at ?? new Date().toISOString(),
+          onboardingStatus: 'pending',
+          onboardingStep: 0,
+          onboardingCompletedAt: undefined,
+          onboardingData: {},
         },
         error: null,
       };
@@ -278,47 +325,31 @@ export class AuthService {
   /**
    * Get the current user with caching for TTFB optimization
    */
-  async getCurrentUser(): Promise<AuthUser | null> {
+  async getCurrentUser(options?: { forceRefresh?: boolean }): Promise<AuthUser | null> {
     try {
       const { data: { user } } = await this.supabase.auth.getUser();
-      
+
       if (!user) {
         return null;
       }
 
       // Use memory cache to prevent redundant database queries during SSR
-      const cacheKey = `user_profile_${user.id}`;
-      const cached = await this.getCachedUserProfile(cacheKey, user.id);
-      
-      if (cached) {
-        return cached;
+      const cacheKey = this.getUserProfileCacheKey(user.id);
+      if (options?.forceRefresh) {
+        this.userProfileCache.delete(cacheKey);
+      } else {
+        const cached = this.getCachedUserProfile(cacheKey);
+        if (cached) {
+          return cached;
+        }
       }
 
       const userProfileResult = await this.userService.getUserProfile(user.id);
 
       if (userProfileResult.success) {
         const userProfile = userProfileResult.data;
-        const authUser = {
-          id: userProfile.id,
-          email: userProfile.email,
-          role: userProfile.role,
-          firstName: userProfile.firstName,
-          lastName: userProfile.lastName,
-          phone: userProfile.phone,
-          avatarUrl: userProfile.avatarUrl,
-          timezone: userProfile.timezone,
-          language: userProfile.language,
-          status: userProfile.status,
-          createdAt: userProfile.createdAt,
-          updatedAt: userProfile.updatedAt,
-          lastSeenAt: userProfile.lastSeenAt,
-          // MFA fields
-          mfaEnabled: userProfile.mfaEnabled,
-          mfaSetupCompleted: userProfile.mfaSetupCompleted,
-          mfaVerifiedAt: userProfile.mfaVerifiedAt,
-          rememberDeviceEnabled: userProfile.rememberDeviceEnabled,
-        };
-        
+        const authUser = this.mapUserProfileToAuthUser(userProfile);
+
         // Cache for 2 minutes to reduce database load
         this.cacheUserProfile(cacheKey, authUser, 120000);
         return authUser;
@@ -419,6 +450,10 @@ export class AuthService {
           createdAt: updatedProfile.createdAt,
           updatedAt: updatedProfile.updatedAt,
           lastSeenAt: updatedProfile.lastSeenAt,
+          onboardingStatus: updatedProfile.onboardingStatus,
+          onboardingStep: updatedProfile.onboardingStep,
+          onboardingCompletedAt: updatedProfile.onboardingCompletedAt,
+          onboardingData: updatedProfile.onboardingData,
           // MFA fields
           mfaEnabled: updatedProfile.mfaEnabled,
           mfaSetupCompleted: updatedProfile.mfaSetupCompleted,
@@ -482,6 +517,10 @@ export class AuthService {
             createdAt: updatedProfile.createdAt,
             updatedAt: updatedProfile.updatedAt,
             lastSeenAt: updatedProfile.lastSeenAt,
+            onboardingStatus: updatedProfile.onboardingStatus,
+            onboardingStep: updatedProfile.onboardingStep,
+            onboardingCompletedAt: updatedProfile.onboardingCompletedAt,
+            onboardingData: updatedProfile.onboardingData,
             // MFA fields
             mfaEnabled: updatedProfile.mfaEnabled,
             mfaSetupCompleted: updatedProfile.mfaSetupCompleted,


### PR DESCRIPTION
## Summary
- add coach and client onboarding API routes that validate input, persist profile data, and refresh the requesting user before returning the updated onboarding payload
- extend the auth service cache with helpers and a force-refresh option so that onboarding completions immediately update cached user data

## Testing
- `pnpm lint --file src/lib/auth/auth.ts` *(fails: repository already contains extensive lint/typecheck violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a52c84c0832080fe7c19d2e77121