### PR TITLE
Add guard script to prevent direct net.http usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "validate:api-docs": "node scripts/validate-api-docs.js",
     "setup:vercel-env": "node scripts/setup-vercel-env.js",
     "verify:auth-hook": "node scripts/verify-auth-hook.js",
+    "verify:no-direct-http": "node scripts/verify-no-direct-http.js",
     "prepare": "husky install",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",

--- a/scripts/verify-no-direct-http.js
+++ b/scripts/verify-no-direct-http.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const ALLOWED_EXTENSIONS = new Set(['.ts', '.tsx', '.sql']);
+const IGNORE_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  'node_modules',
+  'playwright-report',
+  'deployment-test-results',
+]);
+
+function isIgnored(directory) {
+  return IGNORE_DIRECTORIES.has(directory);
+}
+
+function findMatches() {
+  const matches = [];
+
+  /** @type {string[]} */
+  const stack = [REPO_ROOT];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!isIgnored(entry.name)) {
+          stack.push(entryPath);
+        }
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const extension = path.extname(entry.name);
+      if (!ALLOWED_EXTENSIONS.has(extension)) {
+        continue;
+      }
+
+      const relativePath = path.relative(REPO_ROOT, entryPath);
+      const fileContents = fs.readFileSync(entryPath, 'utf8');
+
+      const lines = fileContents.split(/\r?\n/);
+      lines.forEach((line, index) => {
+        if (line.includes('net.http_')) {
+          matches.push({
+            file: relativePath,
+            line: index + 1,
+            content: line.trim(),
+          });
+        }
+      });
+    }
+  }
+
+  return matches;
+}
+
+function main() {
+  const matches = findMatches();
+
+  if (matches.length === 0) {
+    console.log('✅ No direct net.http_* calls found.');
+    console.log(
+      'All HTTP interactions must continue to flow through Next.js API routes or Edge Functions.'
+    );
+    return;
+  }
+
+  console.error(
+    '❌ Found direct net.http_* usage. These calls must be removed so that all HTTP traffic is proxied through Next.js API routes or Edge Functions.'
+  );
+  matches.forEach(match => {
+    console.error(` - ${match.file}:${match.line} -> ${match.content}`);
+  });
+  process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a repository guard script that scans TypeScript and SQL files for net.http_ calls
- expose an npm script so the guard can be run through package.json scripts

## Testing
- node scripts/verify-no-direct-http.js

------
https://chatgpt.com/codex/tasks/task_e_68e143299d70832083f3ca60885f9fad