### PR TITLE
Fix navigation child structure and footer defaults

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -80,6 +80,7 @@ export default async function LocaleLayout({
         <link rel="manifest" href="/manifest.webmanifest" />
         <meta name="theme-color" content="#0ea5e9" />
         {/* iOS PWA support */}
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <link rel="apple-touch-icon" href="/icons/icon-192.svg" />

--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -56,26 +56,26 @@ const footerDefaults: Record<SupportedLocale, FooterContent> = {
       {
         title: 'חברה',
         links: [
-          { label: 'אודות', href: '/about' },
-          { label: 'קריירה', href: '/careers' },
-          { label: 'שותפים', href: '/partners' },
-          { label: 'חדשות', href: '/news' }
+          { label: 'אודות', href: '#hero' },
+          { label: 'קריירה', href: '#cta' },
+          { label: 'שותפים', href: '#platform' },
+          { label: 'חדשות', href: '#testimonial' }
         ]
       },
       {
         title: 'משאבים',
         links: [
-          { label: 'מרכז הדרכה', href: '/resources' },
-          { label: 'ספריית ידע', href: '/resources/library' },
-          { label: 'וובינרים', href: '/resources/webinars' },
-          { label: 'קהילה', href: '/community' }
+          { label: 'מרכז הדרכה', href: '#features' },
+          { label: 'ספריית ידע', href: '#platform' },
+          { label: 'וובינרים', href: '#testimonial' },
+          { label: 'קהילה', href: '#cta' }
         ]
       },
       {
         title: 'צרו קשר',
         links: [
-          { label: 'תמיכה', href: '/support' },
-          { label: 'שאלות נפוצות', href: '/faq' },
+          { label: 'תמיכה', href: 'mailto:support@loom.app' },
+          { label: 'שאלות נפוצות', href: '#cta' },
           { label: 'דברו איתנו', href: 'mailto:hello@loom.app' },
           { label: 'מדיניות פרטיות', href: '/privacy' }
         ]
@@ -116,26 +116,26 @@ const footerDefaults: Record<SupportedLocale, FooterContent> = {
       {
         title: 'Company',
         links: [
-          { label: 'About', href: '/about' },
-          { label: 'Careers', href: '/careers' },
-          { label: 'Partners', href: '/partners' },
-          { label: 'Press', href: '/news' }
+          { label: 'About', href: '#hero' },
+          { label: 'Careers', href: '#cta' },
+          { label: 'Partners', href: '#platform' },
+          { label: 'Press', href: '#testimonial' }
         ]
       },
       {
         title: 'Resources',
         links: [
-          { label: 'Learning center', href: '/resources' },
-          { label: 'Knowledge base', href: '/resources/library' },
-          { label: 'Webinars', href: '/resources/webinars' },
-          { label: 'Community', href: '/community' }
+          { label: 'Learning center', href: '#features' },
+          { label: 'Knowledge base', href: '#platform' },
+          { label: 'Webinars', href: '#testimonial' },
+          { label: 'Community', href: '#cta' }
         ]
       },
       {
         title: 'Contact',
         links: [
-          { label: 'Support', href: '/support' },
-          { label: 'FAQ', href: '/faq' },
+          { label: 'Support', href: 'mailto:support@loom.app' },
+          { label: 'FAQ', href: '#cta' },
           { label: 'Talk with us', href: 'mailto:hello@loom.app' },
           { label: 'Privacy', href: '/privacy' }
         ]

--- a/src/components/navigation/nav-menu.tsx
+++ b/src/components/navigation/nav-menu.tsx
@@ -288,15 +288,19 @@ export function NavMenu() {
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem asChild>
-                  <Link href="/profile" className="flex items-center rtl:space-x-reverse">
-                    <User className="rtl:ml-2 rtl:mr-0 ltr:mr-2 ltr:ml-0 h-4 w-4" />
-                    <span>{t('profile')}</span>
+                  <Link href="/profile">
+                    <span className="flex items-center rtl:space-x-reverse space-x-2">
+                      <User className="h-4 w-4" aria-hidden="true" />
+                      <span>{t('profile')}</span>
+                    </span>
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
-                  <Link href="/settings" className="flex items-center rtl:space-x-reverse">
-                    <Settings className="rtl:ml-2 rtl:mr-0 ltr:mr-2 ltr:ml-0 h-4 w-4" />
-                    <span>{t('settings')}</span>
+                  <Link href="/settings">
+                    <span className="flex items-center rtl:space-x-reverse space-x-2">
+                      <Settings className="h-4 w-4" aria-hidden="true" />
+                      <span>{t('settings')}</span>
+                    </span>
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
@@ -356,8 +360,10 @@ export function NavMenu() {
                 aria-current={active ? 'page' : undefined}
               >
                 <Link href={item.href as '/dashboard'} onClick={() => setIsMobileMenuOpen(false)}>
-                  <item.icon className="h-5 w-5" aria-hidden="true" />
-                  <span>{item.label}</span>
+                  <span className="flex items-center rtl:space-x-reverse space-x-3">
+                    <item.icon className="h-5 w-5" aria-hidden="true" />
+                    <span>{item.label}</span>
+                  </span>
                 </Link>
               </Button>
             );
@@ -379,8 +385,10 @@ export function NavMenu() {
                   aria-current={isActive(item.href) ? "page" : undefined}
                 >
                   <Link href={item.href as '/dashboard'} onClick={() => setIsMobileMenuOpen(false)}>
-                    <item.icon className="h-5 w-5" aria-hidden="true" />
-                    <span>{item.label}</span>
+                    <span className="flex items-center rtl:space-x-reverse space-x-3">
+                      <item.icon className="h-5 w-5" aria-hidden="true" />
+                      <span>{item.label}</span>
+                    </span>
                   </Link>
                 </Button>
               ))}
@@ -402,8 +410,10 @@ export function NavMenu() {
                   aria-current={isActive(item.href) ? "page" : undefined}
                 >
                   <Link href={item.href as '/dashboard'} onClick={() => setIsMobileMenuOpen(false)}>
-                    <item.icon className="h-5 w-5" aria-hidden="true" />
-                    <span>{item.label}</span>
+                    <span className="flex items-center rtl:space-x-reverse space-x-3">
+                      <item.icon className="h-5 w-5" aria-hidden="true" />
+                      <span>{item.label}</span>
+                    </span>
                   </Link>
                 </Button>
               ))}
@@ -425,8 +435,10 @@ export function NavMenu() {
                   aria-current={isActive(item.href) ? "page" : undefined}
                 >
                   <Link href={item.href as '/dashboard'} onClick={() => setIsMobileMenuOpen(false)}>
-                    <item.icon className="h-5 w-5" aria-hidden="true" />
-                    <span>{item.label}</span>
+                    <span className="flex items-center rtl:space-x-reverse space-x-3">
+                      <item.icon className="h-5 w-5" aria-hidden="true" />
+                      <span>{item.label}</span>
+                    </span>
                   </Link>
                 </Button>
               ))}


### PR DESCRIPTION
## Summary
- restructure navigation menu link children so each Next.js Link receives a single element and avoid runtime errors
- update marketing footer default links to use on-page anchors or mailto targets instead of missing routes
- add the modern `mobile-web-app-capable` meta tag alongside the existing iOS PWA metadata

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e22447c9208320b92ba70e2986ee91