### PR TITLE
Fix sign-in redirect handling

### DIFF
--- a/src/components/auth/signin-form.tsx
+++ b/src/components/auth/signin-form.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/components/auth/auth-provider';
 import { Loader2 } from 'lucide-react';
+import { resolveAuthPath, resolveRedirect } from '@/lib/utils/redirect';
 
 interface SigninFormProps {
   redirectTo?: string;
@@ -38,30 +39,27 @@ export function SigninForm({ redirectTo = '/dashboard' }: SigninFormProps) {
 
       if (result.error) {
         setError(result.error);
-        setIsLoading(false);
         return;
       }
 
-      const safeRedirectTo = redirectTo && redirectTo.startsWith('/') ? redirectTo : '/dashboard';
+      const targetPath = resolveRedirect(locale, redirectTo || '/dashboard');
 
       // Check if MFA is required
       if (result.user?.mfaEnabled) {
         const query = new URLSearchParams({
           userId: result.user.id,
-          redirectTo: safeRedirectTo,
+          redirectTo: targetPath,
         });
-        router.push(`/${locale}/auth/mfa-verify?${query.toString()}`);
+        const mfaPath = resolveAuthPath(locale, `/auth/mfa-verify?${query.toString()}`);
+        router.push(mfaPath);
       } else {
         // Auth state is now updated, safe to redirect
-        const finalRedirectTo = /^\/(en|he)\//.test(safeRedirectTo)
-          ? safeRedirectTo
-          : `/${locale}${safeRedirectTo}`;
-        router.push(finalRedirectTo);
+        router.push(targetPath);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : t('signin.error'));
-      setIsLoading(false);
     }
+    setIsLoading(false);
   };
 
   return (

--- a/src/test/components/auth/signin-form.mfa-redirect.test.tsx
+++ b/src/test/components/auth/signin-form.mfa-redirect.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@/i18n/routing', () => ({
   Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   ),
+  routing: {
+    locales: ['en', 'he'],
+    defaultLocale: 'he',
+  },
 }));
 
 describe('SigninForm MFA redirect', () => {
@@ -60,7 +64,7 @@ describe('SigninForm MFA redirect', () => {
     });
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/en/auth/mfa-verify?userId=user-123&redirectTo=%2Fdashboard');
+      expect(mockPush).toHaveBeenCalledWith('/en/auth/mfa-verify?userId=user-123&redirectTo=%2Fen%2Fdashboard');
     });
   });
 });


### PR DESCRIPTION
## Summary
- resolve sign-in redirects with the shared redirect utilities so locale prefixes are applied consistently
- ensure MFA verification link building uses the same sanitized redirect target and add missing routing mock in tests
- reset the sign-in loading state after handling the submit flow to avoid a stuck spinner

## Testing
- npm test --run src/test/components/auth/signin-form.mfa-redirect.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e23b660cbc83209ed42bb2a172c09a