### PR TITLE
Implement coach onboarding load and save endpoints

### DIFF
--- a/src/app/api/onboarding/coach/route.ts
+++ b/src/app/api/onboarding/coach/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+
 import {
   requireAuth,
   requireCoach,
@@ -12,6 +13,7 @@ import {
   withRequestLogging,
   type AuthenticatedUser,
 } from '@/lib/api/utils';
+import { createAuthService } from '@/lib/auth/auth';
 import { createClient } from '@/lib/supabase/server';
 
 // Validation Schemas
@@ -53,6 +55,301 @@ const coachOnboardingSchema = z.object({
 });
 
 type CoachOnboardingData = z.infer<typeof coachOnboardingSchema>;
+
+const coachOnboardingFormSchema = z.object({
+  step: z.number().int().min(1).max(10).default(5),
+  title: z.string().min(2, 'Title is required').max(120, 'Title must be 120 characters or less'),
+  bio: z.string().min(50, 'Bio must be at least 50 characters').max(2000, 'Bio must not exceed 2000 characters'),
+  experienceYears: z.number().int().min(0, 'Experience years cannot be negative').max(100, 'Experience years must be realistic'),
+  specialties: z.array(z.string().min(1).max(100)).min(1, 'At least one specialty is required').max(10, 'Maximum 10 specialties allowed'),
+  credentials: z.array(z.string().min(1).max(120)).max(15, 'Maximum 15 credentials allowed'),
+  languages: z.array(z.string().min(1).max(50)).min(1, 'At least one language is required').max(10, 'Maximum 10 languages allowed'),
+  timezone: z.string().min(2, 'Timezone is required').max(64, 'Timezone must be 64 characters or less'),
+  hourlyRate: z.number().positive('Hourly rate must be positive').max(10000, 'Hourly rate must be realistic'),
+  currency: z.string().length(3, 'Currency must be a 3-letter code').transform((value) => value.toUpperCase()),
+  approach: z.string().min(10, 'Approach must be at least 10 characters').max(2000, 'Approach must not exceed 2000 characters'),
+  location: z.string().min(2, 'Location is required').max(160, 'Location must be 160 characters or less'),
+  availability: z
+    .array(availabilitySlotSchema)
+    .min(1, 'At least one availability slot is required')
+    .max(50, 'Maximum 50 availability slots allowed'),
+});
+
+type CoachOnboardingFormData = z.infer<typeof coachOnboardingFormSchema>;
+
+const normalizeTime = (time: string): string => {
+  if (!time.includes(':')) {
+    return time;
+  }
+
+  return time.length === 5 ? `${time}:00` : time;
+};
+
+const sanitizeCoachFormData = (data: CoachOnboardingFormData): CoachOnboardingFormData => ({
+  ...data,
+  step: data.step ?? 5,
+  title: data.title.trim(),
+  bio: data.bio.trim(),
+  approach: data.approach.trim(),
+  location: data.location.trim(),
+  currency: data.currency.toUpperCase(),
+  specialties: data.specialties.map((item) => item.trim()).filter(Boolean),
+  credentials: data.credentials.map((item) => item.trim()).filter(Boolean),
+  languages: data.languages.map((item) => item.trim()).filter(Boolean),
+  availability: data.availability.map((slot) => ({
+    ...slot,
+    startTime: slot.startTime.trim(),
+    endTime: slot.endTime.trim(),
+  })),
+});
+
+const getCoachProfileSelect = `
+  title,
+  bio,
+  experience_years,
+  specializations,
+  credentials,
+  languages,
+  timezone,
+  session_rate,
+  hourly_rate,
+  currency,
+  location,
+  approach,
+  onboarding_completed_at,
+  default_session_duration,
+  booking_buffer_time
+`;
+
+const rateLimitedCoachHandler = rateLimit(10, 60_000);
+
+async function getAuthenticatedCoach() {
+  const authService = await createAuthService(true);
+  const user = await authService.getCurrentUser();
+
+  if (!user) {
+    return { user: null, error: createErrorResponse('Not authenticated', HTTP_STATUS.UNAUTHORIZED) } as const;
+  }
+
+  if (user.role !== 'coach') {
+    return { user: null, error: createErrorResponse('Coach access required', HTTP_STATUS.FORBIDDEN) } as const;
+  }
+
+  return { user, error: null } as const;
+}
+
+export const GET = withErrorHandling(
+  withRequestLogging(
+    rateLimitedCoachHandler(async (_request: NextRequest) => {
+      const { user, error } = await getAuthenticatedCoach();
+      if (!user) {
+        return error;
+      }
+
+      const supabase = await createClient();
+
+      const [{ data: profile, error: profileError }, { data: availability, error: availabilityError }, { data: userRecord, error: userError }] = await Promise.all([
+        supabase
+          .from('coach_profiles')
+          .select(getCoachProfileSelect)
+          .eq('coach_id', user.id)
+          .maybeSingle(),
+        supabase
+          .from('coach_availability')
+          .select('day_of_week, start_time, end_time, timezone, is_available')
+          .eq('coach_id', user.id)
+          .order('day_of_week', { ascending: true })
+          .order('start_time', { ascending: true }),
+        supabase
+          .from('users')
+          .select('onboarding_status, onboarding_step, onboarding_completed_at, timezone')
+          .eq('id', user.id)
+          .maybeSingle(),
+      ]);
+
+      if (profileError) {
+        console.error('Failed to load coach profile:', profileError);
+        return createErrorResponse('Failed to load coach profile data', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      if (availabilityError) {
+        console.error('Failed to load coach availability:', availabilityError);
+        return createErrorResponse('Failed to load availability data', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      if (userError) {
+        console.error('Failed to load user onboarding status:', userError);
+        return createErrorResponse('Failed to load onboarding status', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      const fallbackTimezone = userRecord?.timezone || 'UTC';
+      const availabilitySlots = (availability || [])
+        .filter((slot) => slot.is_available !== false)
+        .map((slot) => ({
+          dayOfWeek: slot.day_of_week ?? 0,
+          startTime: typeof slot.start_time === 'string' ? slot.start_time.slice(0, 5) : '09:00',
+          endTime: typeof slot.end_time === 'string' ? slot.end_time.slice(0, 5) : '17:00',
+        }));
+
+      return createSuccessResponse({
+        profile: {
+          title: profile?.title ?? '',
+          bio: profile?.bio ?? '',
+          experienceYears: typeof profile?.experience_years === 'number' ? profile.experience_years : 0,
+          specialties: Array.isArray(profile?.specializations) ? profile?.specializations : [],
+          credentials: Array.isArray(profile?.credentials) ? profile?.credentials : [],
+          languages: Array.isArray(profile?.languages) ? profile?.languages : [],
+          timezone: profile?.timezone ?? fallbackTimezone,
+          hourlyRate: typeof profile?.hourly_rate === 'number'
+            ? profile?.hourly_rate
+            : typeof profile?.session_rate === 'number'
+              ? profile.session_rate
+              : 100,
+          currency: profile?.currency ?? 'USD',
+          approach: profile?.approach ?? '',
+          location: profile?.location ?? '',
+        },
+        availability: availabilitySlots,
+        onboarding: {
+          status: (userRecord?.onboarding_status as 'pending' | 'in_progress' | 'completed' | undefined) ?? 'pending',
+          step: userRecord?.onboarding_step ?? 5,
+          completedAt: userRecord?.onboarding_completed_at ?? null,
+        },
+      });
+    }),
+    { name: 'GET /api/onboarding/coach' }
+  )
+);
+
+export const PUT = withErrorHandling(
+  withRequestLogging(
+    rateLimitedCoachHandler(async (request: NextRequest) => {
+      const { user, error } = await getAuthenticatedCoach();
+      if (!user) {
+        return error;
+      }
+
+      const payload = await request.json();
+      const validation = validateRequestBody(coachOnboardingFormSchema, payload, {
+        sanitize: true,
+        maxSize: 24 * 1024,
+      });
+
+      if (!validation.success) {
+        return createErrorResponse(validation.error, HTTP_STATUS.BAD_REQUEST);
+      }
+
+      const sanitized = sanitizeCoachFormData(validation.data);
+      const supabase = await createClient();
+
+      const { data: existingProfile, error: existingProfileError } = await supabase
+        .from('coach_profiles')
+        .select('default_session_duration, booking_buffer_time')
+        .eq('coach_id', user.id)
+        .maybeSingle();
+
+      if (existingProfileError) {
+        console.error('Failed to load existing coach profile:', existingProfileError);
+        return createErrorResponse('Failed to load existing coach profile', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      const now = new Date().toISOString();
+
+      const { error: profileError } = await supabase
+        .from('coach_profiles')
+        .upsert({
+          coach_id: user.id,
+          title: sanitized.title,
+          bio: sanitized.bio,
+          experience_years: sanitized.experienceYears,
+          specializations: sanitized.specialties,
+          credentials: sanitized.credentials,
+          languages: sanitized.languages,
+          timezone: sanitized.timezone,
+          session_rate: sanitized.hourlyRate,
+          hourly_rate: sanitized.hourlyRate,
+          currency: sanitized.currency,
+          location: sanitized.location,
+          approach: sanitized.approach,
+          onboarding_completed_at: now,
+          updated_at: now,
+          default_session_duration: existingProfile?.default_session_duration ?? 60,
+          booking_buffer_time: existingProfile?.booking_buffer_time ?? 15,
+        }, { onConflict: 'coach_id' });
+
+      if (profileError) {
+        console.error('Failed to update coach profile:', profileError);
+        return createErrorResponse('Failed to save coach profile', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      const { error: deleteAvailabilityError } = await supabase
+        .from('coach_availability')
+        .delete()
+        .eq('coach_id', user.id);
+
+      if (deleteAvailabilityError) {
+        console.error('Failed to reset coach availability:', deleteAvailabilityError);
+        return createErrorResponse('Failed to reset availability', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      const availabilityRecords = sanitized.availability.map((slot) => ({
+        coach_id: user.id,
+        day_of_week: slot.dayOfWeek,
+        start_time: normalizeTime(slot.startTime),
+        end_time: normalizeTime(slot.endTime),
+        timezone: sanitized.timezone,
+        is_available: true,
+        created_at: now,
+        updated_at: now,
+      }));
+
+      if (availabilityRecords.length > 0) {
+        const { error: insertAvailabilityError } = await supabase
+          .from('coach_availability')
+          .insert(availabilityRecords);
+
+        if (insertAvailabilityError) {
+          console.error('Failed to save coach availability:', insertAvailabilityError);
+          return createErrorResponse('Failed to save availability', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+        }
+      }
+
+      const onboardingStep = Math.max(sanitized.step ?? 5, 5);
+
+      const { error: userUpdateError } = await supabase
+        .from('users')
+        .update({
+          timezone: sanitized.timezone,
+          onboarding_status: 'completed',
+          onboarding_step: onboardingStep,
+          onboarding_completed_at: now,
+          updated_at: now,
+        })
+        .eq('id', user.id);
+
+      if (userUpdateError) {
+        console.error('Failed to update user onboarding status:', userUpdateError);
+        return createErrorResponse('Failed to update onboarding status', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      }
+
+      const authService = await createAuthService(true);
+      const refreshedUser = await authService.getCurrentUser({ forceRefresh: true });
+
+      return createSuccessResponse(
+        {
+          user: {
+            onboardingStatus: (refreshedUser?.onboardingStatus ?? 'completed') as 'pending' | 'in_progress' | 'completed',
+            onboardingStep: refreshedUser?.onboardingStep ?? onboardingStep,
+            onboardingCompletedAt: refreshedUser?.onboardingCompletedAt ?? now,
+            timezone: refreshedUser?.timezone ?? sanitized.timezone,
+          },
+        },
+        'Coach onboarding updated successfully'
+      );
+    }),
+    { name: 'PUT /api/onboarding/coach' }
+  )
+);
 
 /**
  * POST /api/onboarding/coach
@@ -253,13 +550,16 @@ async function handleCoachOnboarding(
   }
 }
 
+const coachOnboardingHandler = requireCoach(handleCoachOnboarding) as (
+  user: AuthenticatedUser,
+  request: NextRequest
+) => Promise<NextResponse>;
+
 // Apply middleware: error handling -> logging -> rate limiting -> auth -> role check -> handler
 export const POST = withErrorHandling(
   withRequestLogging(
     rateLimit(5, 60000)( // 5 requests per minute
-      requireAuth(
-        requireCoach(handleCoachOnboarding)
-      )
+      requireAuth(coachOnboardingHandler)
     ),
     { name: 'POST /api/onboarding/coach' }
   )

--- a/src/components/onboarding/coach-onboarding-form.tsx
+++ b/src/components/onboarding/coach-onboarding-form.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { TagInput } from '@/components/client/tag-input';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -16,8 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { TagInput } from '@/components/client/tag-input';
-import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
 import type { AuthUser } from '@/lib/auth/auth';
 
 interface CoachOnboardingResponse {
@@ -89,7 +89,10 @@ export function CoachOnboardingForm({ user, onUserUpdate }: CoachOnboardingFormP
   const { data, isLoading } = useQuery<CoachOnboardingResponse>({
     queryKey: ['coach-onboarding'],
     queryFn: async () => {
-      const response = await fetch('/api/onboarding/coach', { cache: 'no-store' });
+      const response = await fetch('/api/onboarding/coach', {
+        cache: 'no-store',
+        credentials: 'include',
+      });
       const body = await response.json();
       if (!response.ok) {
         throw new Error(body?.error || commonT('error.load'));
@@ -145,6 +148,7 @@ export function CoachOnboardingForm({ user, onUserUpdate }: CoachOnboardingFormP
       const response = await fetch('/api/onboarding/coach', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
           ...payload,
           currency: payload.currency.toUpperCase(),


### PR DESCRIPTION
## Summary
- add authenticated GET and PUT handlers for coach onboarding to load and persist profile and availability data
- sanitize and normalize onboarding payloads while refreshing the cached user after updates
- update the coach onboarding form to call the new API endpoints with credentials-aware fetches

## Testing
- npx eslint src/app/api/onboarding/coach/route.ts src/components/onboarding/coach-onboarding-form.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4bc2b15488320a26fad3d8b57829c