### PR TITLE
feat: finalize coach dashboard analytics

### DIFF
--- a/src/app/api/coach/activity/route.ts
+++ b/src/app/api/coach/activity/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from 'next/server';
-import { authService } from '@/lib/services/auth-service';
-import { ApiResponseHelper } from '@/lib/api/types';
+
 import { ApiError } from '@/lib/api/errors';
+import { ApiResponseHelper } from '@/lib/api/types';
+import { authService } from '@/lib/services/auth-service';
 import { createServerClient } from '@/lib/supabase/server';
 
 interface RecentActivity {

--- a/src/app/api/coach/activity/route.ts
+++ b/src/app/api/coach/activity/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 import { ApiError } from '@/lib/api/errors';
 import { ApiResponseHelper } from '@/lib/api/types';
 import { authService } from '@/lib/services/auth-service';
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 interface RecentActivity {
   id: string;
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
     console.log('[/api/coach/activity] Fetching activity for coach:', coachId);
 
-    const supabase = createServerClient();
+    const supabase = createClient();
 
     // Fetch recent activities from different sources
     const activities: RecentActivity[] = [];

--- a/src/app/api/coach/clients/[id]/route.ts
+++ b/src/app/api/coach/clients/[id]/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 import { ApiError } from '@/lib/api/errors';
 import { ApiResponseHelper } from '@/lib/api/types';
 import { authService } from '@/lib/services/auth-service';
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 interface ClientDetailResponse {
   id: string;
@@ -56,7 +56,7 @@ export async function GET(
       return ApiResponseHelper.badRequest('Client ID is required');
     }
 
-    const supabase = createServerClient();
+    const supabase = createClient();
 
     // Get client details
     const { data: clientUser, error: clientError } = await supabase
@@ -319,7 +319,7 @@ export async function PUT(
       return ApiResponseHelper.badRequest('Notes must be a string');
     }
 
-    const supabase = createServerClient();
+    const supabase = createClient();
 
     // Verify this client has sessions with the current coach
     const { data: coachClientRelation, error: relationError } = await supabase

--- a/src/app/api/coach/clients/route.ts
+++ b/src/app/api/coach/clients/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 import { ApiError } from '@/lib/api/errors';
 import { ApiResponseHelper } from '@/lib/api/types';
 import { authService } from '@/lib/services/auth-service';
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 interface Client {
   id: string;
@@ -78,7 +78,7 @@ export async function GET(request: NextRequest): Promise<Response> {
     const statusFilter = searchParams.get('status') || 'all';
     const sortBy = searchParams.get('sortBy') || 'name';
 
-    const supabase = createServerClient();
+    const supabase = createClient();
 
     console.log('[/api/coach/clients] Fetching clients for coach:', coachId);
 

--- a/src/app/api/coach/insights/route.ts
+++ b/src/app/api/coach/insights/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getCoachSessionRate } from '@/lib/coach-dashboard/coach-profile';
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 const insightsQuerySchema = z.object({
   timeRange: z.enum(['7d', '30d', '90d', '1y']).default('30d'),
@@ -42,7 +42,7 @@ function getTimeRange(range: string): TimeRange {
 
 export async function GET(request: NextRequest) {
   try {
-    const supabase = await createServerClient();
+    const supabase = createClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
 
     if (authError || !user) {

--- a/src/app/api/coach/insights/route.ts
+++ b/src/app/api/coach/insights/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase/server';
-import { getSessionRate } from '@/lib/config/analytics-constants';
 import { z } from 'zod';
+
+import { getCoachSessionRate } from '@/lib/coach-dashboard/coach-profile';
+import { createServerClient } from '@/lib/supabase/server';
 
 const insightsQuerySchema = z.object({
   timeRange: z.enum(['7d', '30d', '90d', '1y']).default('30d'),
@@ -94,6 +95,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch session data' }, { status: 500 });
     }
 
+    const sessionIds = sessions?.map((session) => session.id) ?? [];
+
     // Get coach notes for insights
     const { data: notes, error: notesError } = await supabase
       .from('coach_notes')
@@ -108,8 +111,14 @@ export async function GET(request: NextRequest) {
 
     // Get client reflections for mood/progress insights
     const clientIds = [...new Set(sessions?.map(s => s.client_id) || [])];
-    let reflections: any[] = [];
-    
+    type ReflectionRow = {
+      client_id: string;
+      mood_rating: number | null;
+      progress_rating: number | null;
+      created_at: string;
+    };
+    let reflections: ReflectionRow[] = [];
+
     if (clientIds.length > 0) {
       const { data: reflectionsData, error: reflectionsError } = await supabase
         .from('reflections')
@@ -122,6 +131,58 @@ export async function GET(request: NextRequest) {
         reflections = reflectionsData || [];
       }
     }
+
+    let feedbackResult: { data: { session_id: string; overall_rating: number | null }[] | null; error: unknown | null } = { data: [], error: null };
+    let ratingsResult: { data: { session_id: string; rating: number | null }[] | null; error: unknown | null } = { data: [], error: null };
+
+    if (sessionIds.length > 0) {
+      [feedbackResult, ratingsResult] = await Promise.all([
+        supabase
+          .from('session_feedback')
+          .select('session_id, overall_rating')
+          .eq('coach_id', user.id)
+          .in('session_id', sessionIds),
+        supabase
+          .from('session_ratings')
+          .select('session_id, rating')
+          .eq('coach_id', user.id)
+          .in('session_id', sessionIds),
+      ]);
+    }
+
+    const coachRate = await getCoachSessionRate(supabase, user.id);
+
+    if (feedbackResult.error) {
+      console.warn('Error fetching session feedback for insights:', feedbackResult.error);
+    }
+    if (ratingsResult.error) {
+      console.warn('Error fetching session ratings for insights:', ratingsResult.error);
+    }
+
+    const ratingBySession = new Map<string, number>();
+
+    feedbackResult.data
+      ?.filter((feedback) => feedback.overall_rating != null)
+      .forEach((feedback) => {
+        const parsed = Number(feedback.overall_rating);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          ratingBySession.set(feedback.session_id, parsed);
+        }
+      });
+
+    ratingsResult.data
+      ?.filter((rating) => rating.rating != null)
+      .forEach((rating) => {
+        const parsed = Number(rating.rating);
+        if (!ratingBySession.has(rating.session_id) && Number.isFinite(parsed) && parsed > 0) {
+          ratingBySession.set(rating.session_id, parsed);
+        }
+      });
+
+    const feedbackRatings = Array.from(ratingBySession.values());
+    const averageFeedbackRating = feedbackRatings.length > 0
+      ? Math.round(((feedbackRatings.reduce((sum, value) => sum + value, 0) / feedbackRatings.length) + Number.EPSILON) * 10) / 10
+      : 0;
 
     // Calculate metrics
     const totalSessions = sessions?.length || 0;
@@ -139,20 +200,23 @@ export async function GET(request: NextRequest) {
     const completionRate = totalSessions > 0 ? Math.round((completedSessions / totalSessions) * 100) : 0;
 
     // Calculate average mood rating from client reflections
-    const moodRatings = reflections.filter(r => r.mood_rating != null).map(r => r.mood_rating);
+    const moodRatings = reflections
+      .map(reflection => reflection.mood_rating)
+      .filter((rating): rating is number => rating != null);
     const averageMoodRating = moodRatings.length > 0 
       ? Math.round((moodRatings.reduce((sum, rating) => sum + rating, 0) / moodRatings.length) * 10) / 10 
       : 0;
 
     // Calculate average progress rating
-    const progressRatings = reflections.filter(r => r.progress_rating != null).map(r => r.progress_rating);
+    const progressRatings = reflections
+      .map(reflection => reflection.progress_rating)
+      .filter((rating): rating is number => rating != null);
     const averageProgressRating = progressRatings.length > 0 
       ? Math.round((progressRatings.reduce((sum, rating) => sum + rating, 0) / progressRatings.length) * 10) / 10 
       : 0;
 
     // Generate session metrics for charts (daily aggregation)
-    const sessionMetrics = [];
-    const dailySessions = new Map();
+    const dailySessions = new Map<string, { date: string; completed: number; cancelled: number; total: number }>();
 
     sessions?.forEach(session => {
       const date = session.scheduled_at.split('T')[0];
@@ -164,7 +228,7 @@ export async function GET(request: NextRequest) {
           total: 0
         });
       }
-      const dayData = dailySessions.get(date);
+      const dayData = dailySessions.get(date)!;
       dayData.total++;
       if (session.status === 'completed') dayData.completed++;
       if (session.status === 'cancelled') dayData.cancelled++;
@@ -176,7 +240,7 @@ export async function GET(request: NextRequest) {
     // Fill in missing dates with zero values
     const startDate = new Date(start);
     const endDate = new Date(end);
-    const filledMetrics = [];
+    const filledMetrics: { date: string; completed: number; cancelled: number; total: number }[] = [];
     
     for (let date = new Date(startDate); date <= endDate; date.setDate(date.getDate() + 1)) {
       const dateStr = date.toISOString().split('T')[0];
@@ -190,11 +254,21 @@ export async function GET(request: NextRequest) {
     }
 
     // Calculate client progress data
-    const clientProgress = [];
-    const clientMap = new Map();
+    const clientMap = new Map<string, {
+      id: string;
+      name: string;
+      sessionsCompleted: number;
+      totalSessions: number;
+      averageMood: number;
+      averageProgress: number;
+      lastSession: string | null;
+    }>();
 
     sessions?.forEach(session => {
       const clientId = session.client_id;
+      if (!clientId) {
+        return;
+      }
       const client = Array.isArray(session.users) ? session.users[0] : session.users;
 
       if (!clientMap.has(clientId)) {
@@ -209,7 +283,7 @@ export async function GET(request: NextRequest) {
         });
       }
       
-      const clientData = clientMap.get(clientId);
+      const clientData = clientMap.get(clientId)!;
       clientData.totalSessions++;
       if (session.status === 'completed') {
         clientData.sessionsCompleted++;
@@ -223,22 +297,22 @@ export async function GET(request: NextRequest) {
     // Add reflection data to client progress
     reflections.forEach(reflection => {
       const clientData = clientMap.get(reflection.client_id);
-      if (clientData) {
-        // This is a simplified calculation - in a real app you'd want more sophisticated aggregation
-        if (reflection.mood_rating) {
-          clientData.averageMood = reflection.mood_rating;
-        }
-        if (reflection.progress_rating) {
-          clientData.averageProgress = reflection.progress_rating;
-        }
+      if (!clientData) {
+        return;
+      }
+      // This is a simplified calculation - in a real app you'd want more sophisticated aggregation
+      if (reflection.mood_rating != null) {
+        clientData.averageMood = reflection.mood_rating;
+      }
+      if (reflection.progress_rating != null) {
+        clientData.averageProgress = reflection.progress_rating;
       }
     });
 
     const clientProgressArray = Array.from(clientMap.values()).slice(0, 10); // Limit to top 10 clients
 
-    // Calculate revenue using centralized session rate configuration
-    const sessionRate = getSessionRate(user.id);
-    const estimatedRevenue = completedSessions * sessionRate;
+    // Calculate revenue using the coach profile configuration
+    const estimatedRevenue = Number((completedSessions * coachRate.rate).toFixed(2));
 
     const insights = {
       overview: {
@@ -251,6 +325,8 @@ export async function GET(request: NextRequest) {
         averageMoodRating,
         averageProgressRating,
         estimatedRevenue,
+        revenueCurrency: coachRate.currency,
+        averageFeedbackRating,
         notesCount: notes?.length || 0
       },
       sessionMetrics: filledMetrics,

--- a/src/app/api/coach/stats/route.ts
+++ b/src/app/api/coach/stats/route.ts
@@ -5,7 +5,7 @@ import { ApiResponseHelper } from '@/lib/api/types';
 import { getCoachSessionRate } from '@/lib/coach-dashboard/coach-profile';
 import { getDefaultCoachRating } from '@/lib/config/analytics-constants';
 import { authService } from '@/lib/services/auth-service';
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 interface DashboardStats {
   totalSessions: number;
@@ -45,7 +45,7 @@ export async function GET(_request: NextRequest): Promise<Response> {
     }
 
     const coachId = session.user.id;
-    const supabase = createServerClient();
+    const supabase = createClient();
 
     console.log('[/api/coach/stats] Fetching stats for coach:', coachId);
 

--- a/src/app/api/coach/stats/route.ts
+++ b/src/app/api/coach/stats/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest } from 'next/server';
-import { authService } from '@/lib/services/auth-service';
-import { ApiResponseHelper } from '@/lib/api/types';
+
 import { ApiError } from '@/lib/api/errors';
+import { ApiResponseHelper } from '@/lib/api/types';
+import { getCoachSessionRate } from '@/lib/coach-dashboard/coach-profile';
+import { getDefaultCoachRating } from '@/lib/config/analytics-constants';
+import { authService } from '@/lib/services/auth-service';
 import { createServerClient } from '@/lib/supabase/server';
-import { getSessionRate, getDefaultCoachRating } from '@/lib/config/analytics-constants';
 
 interface DashboardStats {
   totalSessions: number;
@@ -16,7 +18,7 @@ interface DashboardStats {
   totalRevenue: number;
 }
 
-export async function GET(request: NextRequest): Promise<Response> {
+export async function GET(_request: NextRequest): Promise<Response> {
   try {
     // Verify authentication and get user
     const session = await authService.getSession();
@@ -52,79 +54,121 @@ export async function GET(request: NextRequest): Promise<Response> {
     const startOfWeek = new Date(now);
     startOfWeek.setDate(now.getDate() - now.getDay());
     startOfWeek.setHours(0, 0, 0, 0);
+    const endOfWeek = new Date(startOfWeek);
+    endOfWeek.setDate(startOfWeek.getDate() + 7);
+    endOfWeek.setHours(23, 59, 59, 999);
 
-    // Fetch session statistics
-    const { data: sessionStats, error: sessionError } = await supabase
+    // Fetch session statistics and coach rate concurrently
+    const sessionsPromise = supabase
       .from('sessions')
       .select('id, status, scheduled_at, client_id')
       .eq('coach_id', coachId);
 
-    if (sessionError) {
-      console.error('[/api/coach/stats] Error fetching sessions:', sessionError);
+    const [sessionsResult, coachRate] = await Promise.all([
+      sessionsPromise,
+      getCoachSessionRate(supabase, coachId),
+    ]);
+
+    if (sessionsResult.error) {
+      console.error('[/api/coach/stats] Error fetching sessions:', sessionsResult.error);
     }
+
+    const sessionStats = sessionsResult.data ?? [];
 
     console.log('[/api/coach/stats] Sessions query result:', {
-      count: sessionStats?.length || 0,
-      hasError: !!sessionError,
-      error: sessionError?.message
+      count: sessionStats.length,
+      hasError: !!sessionsResult.error,
+      error: sessionsResult.error?.message,
     });
 
-    const totalSessions = sessionStats?.length || 0;
-    const completedSessions = sessionStats?.filter(s => s.status === 'completed').length || 0;
-    const upcomingSessions = sessionStats?.filter(s => 
-      s.status === 'scheduled' && new Date(s.scheduled_at) > now
-    ).length || 0;
-    
-    const thisWeekSessions = sessionStats?.filter(s => 
-      new Date(s.scheduled_at) >= startOfWeek && new Date(s.scheduled_at) <= now
-    ).length || 0;
+    const totalSessions = sessionStats.length;
+    const completedSessions = sessionStats.filter((s) => s.status === 'completed').length;
+    const upcomingSessions = sessionStats.filter((s) => {
+      if (s.status !== 'scheduled') return false;
+      const scheduledAt = new Date(s.scheduled_at);
+      return scheduledAt > now;
+    }).length;
 
-    // Calculate unique clients
-    const uniqueClientIds = new Set(sessionStats?.map(s => s.client_id) || []);
+    const thisWeekSessions = sessionStats.filter((s) => {
+      if (s.status === 'cancelled') return false;
+      const scheduledAt = new Date(s.scheduled_at);
+      return scheduledAt >= startOfWeek && scheduledAt <= endOfWeek;
+    }).length;
+
+    const uniqueClientIds = new Set(sessionStats.map((s) => s.client_id).filter(Boolean));
     const totalClients = uniqueClientIds.size;
 
-    // Calculate active clients (had a session in the last 30 days)
-    const thirtyDaysAgo = new Date();
+    const thirtyDaysAgo = new Date(now);
     thirtyDaysAgo.setDate(now.getDate() - 30);
-    
-    const recentClientIds = new Set(
-      sessionStats?.filter(s => 
-        new Date(s.scheduled_at) >= thirtyDaysAgo && 
-        (s.status === 'completed' || s.status === 'scheduled')
-      ).map(s => s.client_id) || []
-    );
+
+    const recentClientIds = new Set<string>();
+    sessionStats.forEach((session) => {
+      if (!session.client_id) return;
+      const scheduledAt = new Date(session.scheduled_at);
+      if (scheduledAt >= thirtyDaysAgo && session.status !== 'cancelled') {
+        recentClientIds.add(session.client_id);
+      }
+    });
+
     const activeClients = recentClientIds.size;
 
-    // Calculate real revenue from session rates
-    // Use default session rate (coach_profiles table doesn't exist in current schema)
-    const sessionRate = getSessionRate();
-    const totalRevenue = completedSessions * sessionRate;
+    // Calculate revenue using the coach's configured session rate
+    const totalRevenue = Number((completedSessions * coachRate.rate).toFixed(2));
 
-    // Calculate real average rating from session reflections
+    // Calculate average rating from feedback/ratings tables
     let averageRating = 0;
-    if (completedSessions > 0) {
-      const completedSessionIds = sessionStats
-        ?.filter(s => s.status === 'completed')
-        .map(s => s.id) || [];
-      
-      if (completedSessionIds.length > 0) {
-        const { data: reflections } = await supabase
-          .from('reflections')
-          .select('mood_rating')
-          .in('session_id', completedSessionIds)
-          .not('mood_rating', 'is', null);
-        
-        if (reflections && reflections.length > 0) {
-          const validRatings = reflections.filter(r => r.mood_rating != null && r.mood_rating > 0);
-          if (validRatings.length > 0) {
-            averageRating = validRatings.reduce((sum, r) => sum + (r.mood_rating || 0), 0) / validRatings.length;
-            averageRating = Math.round(averageRating * 10) / 10; // Round to 1 decimal
+    const completedSessionIds = sessionStats
+      .filter((s) => s.status === 'completed')
+      .map((s) => s.id);
+
+    if (completedSessionIds.length > 0) {
+      const [feedbackResult, ratingsResult] = await Promise.all([
+        supabase
+          .from('session_feedback')
+          .select('session_id, overall_rating')
+          .eq('coach_id', coachId)
+          .in('session_id', completedSessionIds),
+        supabase
+          .from('session_ratings')
+          .select('session_id, rating')
+          .eq('coach_id', coachId)
+          .in('session_id', completedSessionIds),
+      ]);
+
+      if (feedbackResult.error) {
+        console.warn('[/api/coach/stats] Failed to load session feedback', feedbackResult.error);
+      }
+      if (ratingsResult.error) {
+        console.warn('[/api/coach/stats] Failed to load session ratings', ratingsResult.error);
+      }
+
+      const ratingBySession = new Map<string, number>();
+
+      feedbackResult.data
+        ?.filter((feedback) => feedback.overall_rating != null)
+        .forEach((feedback) => {
+          const rating = Number(feedback.overall_rating);
+          if (Number.isFinite(rating) && rating > 0) {
+            ratingBySession.set(feedback.session_id, rating);
           }
-        }
+        });
+
+      ratingsResult.data
+        ?.filter((rating) => rating.rating != null)
+        .forEach((rating) => {
+          const parsed = Number(rating.rating);
+          if (!ratingBySession.has(rating.session_id) && Number.isFinite(parsed) && parsed > 0) {
+            ratingBySession.set(rating.session_id, parsed);
+          }
+        });
+
+      const ratingValues = Array.from(ratingBySession.values());
+      if (ratingValues.length > 0) {
+        const sum = ratingValues.reduce((total, value) => total + value, 0);
+        averageRating = Math.round(((sum / ratingValues.length) + Number.EPSILON) * 10) / 10;
       }
     }
-    
-    // Fallback to configured default if no ratings available
+
     if (averageRating === 0) {
       averageRating = getDefaultCoachRating();
     }

--- a/src/components/coach/coach-dashboard.tsx
+++ b/src/components/coach/coach-dashboard.tsx
@@ -67,7 +67,7 @@ interface Client {
   avatar?: string;
   lastSession?: string;
   totalSessions: number;
-  status: 'active' | 'inactive';
+  status: 'active' | 'inactive' | 'pending';
 }
 
 interface RecentActivity {

--- a/src/components/dashboard/coach/client-snapshot.tsx
+++ b/src/components/dashboard/coach/client-snapshot.tsx
@@ -24,7 +24,7 @@ interface CoachClient {
   firstName: string;
   lastName: string;
   email: string;
-  status: 'active' | 'inactive';
+  status: 'active' | 'inactive' | 'pending';
   nextSession?: string;
   lastSession?: string;
 }
@@ -71,7 +71,7 @@ export function CoachClientSnapshot({ translations }: { translations: DashboardT
     staleTime: 60_000,
   });
 
-  const pendingClients = data?.clients.filter((client) => client.status === 'inactive') ?? [];
+  const pendingClients = data?.clients.filter((client) => client.status === 'inactive' || client.status === 'pending') ?? [];
 
   const nextSessions = useMemo(() => {
     return (data?.clients ?? [])

--- a/src/lib/coach-dashboard/coach-profile.ts
+++ b/src/lib/coach-dashboard/coach-profile.ts
@@ -1,7 +1,7 @@
 import { ANALYTICS_CONFIG } from '@/lib/config/analytics-constants';
-import type { createServerClient } from '@/lib/supabase/server';
+import type { createClient } from '@/lib/supabase/server';
 
-type SupabaseClientLike = ReturnType<typeof createServerClient>;
+type SupabaseClientLike = ReturnType<typeof createClient>;
 
 interface CoachSessionRateResult {
   rate: number;

--- a/src/lib/coach-dashboard/coach-profile.ts
+++ b/src/lib/coach-dashboard/coach-profile.ts
@@ -1,0 +1,46 @@
+import { ANALYTICS_CONFIG } from '@/lib/config/analytics-constants';
+import type { createServerClient } from '@/lib/supabase/server';
+
+type SupabaseClientLike = ReturnType<typeof createServerClient>;
+
+interface CoachSessionRateResult {
+  rate: number;
+  currency: string;
+}
+
+/**
+ * Fetches the per-session rate configured for a coach. If no profile exists
+ * (or the query fails) we fall back to the default analytics configuration so
+ * that revenue calculations still succeed.
+ */
+export async function getCoachSessionRate(
+  supabase: SupabaseClientLike,
+  coachId: string
+): Promise<CoachSessionRateResult> {
+  const { data, error } = await supabase
+    .from('coach_profiles')
+    .select('session_rate, currency')
+    .eq('coach_id', coachId)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('[coach-profile] Failed to load coach profile for rate', {
+      coachId,
+      error: error.message,
+    });
+  }
+
+  if (!data) {
+    return {
+      rate: ANALYTICS_CONFIG.DEFAULT_SESSION_RATE,
+      currency: 'USD',
+    };
+  }
+
+  const parsedRate = Number(data.session_rate ?? ANALYTICS_CONFIG.DEFAULT_SESSION_RATE);
+
+  return {
+    rate: Number.isFinite(parsedRate) ? parsedRate : ANALYTICS_CONFIG.DEFAULT_SESSION_RATE,
+    currency: data.currency || 'USD',
+  };
+}

--- a/supabase/seed_analytics_test_data.sql
+++ b/supabase/seed_analytics_test_data.sql
@@ -72,6 +72,57 @@ ON CONFLICT (session_id) DO UPDATE SET
   review = EXCLUDED.review,
   created_at = EXCLUDED.created_at;
 
+-- Configure coach profiles so dashboard revenue uses per-coach pricing
+INSERT INTO coach_profiles (id, coach_id, session_rate, currency, specializations, bio, experience_years, updated_at)
+VALUES
+  ('880e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440001', 125.00, 'USD', ARRAY['leadership', 'executive'], 'Executive leadership coach with a focus on career transitions.', 8, NOW()),
+  ('880e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440002', 95.00, 'USD', ARRAY['career development'], 'Career strategist helping mid-level managers grow.', 6, NOW()),
+  ('880e8400-e29b-41d4-a716-446655440003', '550e8400-e29b-41d4-a716-446655440003', 110.00, 'USD', ARRAY['wellness', 'resilience'], 'Holistic coach supporting wellbeing and balance.', 7, NOW())
+ON CONFLICT (coach_id) DO UPDATE SET
+  session_rate = EXCLUDED.session_rate,
+  currency = EXCLUDED.currency,
+  specializations = EXCLUDED.specializations,
+  bio = EXCLUDED.bio,
+  experience_years = EXCLUDED.experience_years,
+  updated_at = NOW();
+
+-- Seed client goals so progress widgets display meaningful data
+INSERT INTO client_goals (id, client_id, coach_id, title, description, category, target_date, status, progress_percentage, priority, created_at, updated_at)
+VALUES
+  ('990e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440011', '550e8400-e29b-41d4-a716-446655440001', 'Improve leadership presence', 'Build confidence when presenting to senior stakeholders.', 'leadership', CURRENT_DATE + INTERVAL '30 days', 'active', 55, 'high', NOW() - INTERVAL '20 days', NOW() - INTERVAL '2 days'),
+  ('990e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440012', '550e8400-e29b-41d4-a716-446655440001', 'Establish morning routine', 'Design a repeatable morning routine to improve focus.', 'productivity', CURRENT_DATE + INTERVAL '45 days', 'active', 40, 'medium', NOW() - INTERVAL '18 days', NOW() - INTERVAL '3 days'),
+  ('990e8400-e29b-41d4-a716-446655440003', '550e8400-e29b-41d4-a716-446655440013', '550e8400-e29b-41d4-a716-446655440002', 'Launch pilot program', 'Deliver the first cohort of a new coaching pilot.', 'strategy', CURRENT_DATE + INTERVAL '14 days', 'active', 70, 'high', NOW() - INTERVAL '12 days', NOW() - INTERVAL '1 day'),
+  ('990e8400-e29b-41d4-a716-446655440004', '550e8400-e29b-41d4-a716-446655440014', '550e8400-e29b-41d4-a716-446655440002', 'Increase client retention', 'Implement new retention experiments for top customers.', 'business', CURRENT_DATE + INTERVAL '60 days', 'paused', 20, 'medium', NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days'),
+  ('990e8400-e29b-41d4-a716-446655440005', '550e8400-e29b-41d4-a716-446655440015', '550e8400-e29b-41d4-a716-446655440003', 'Build wellbeing toolkit', 'Develop sustainable habits for stress management.', 'wellness', CURRENT_DATE + INTERVAL '21 days', 'active', 65, 'high', NOW() - INTERVAL '15 days', NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  description = EXCLUDED.description,
+  category = EXCLUDED.category,
+  target_date = EXCLUDED.target_date,
+  status = EXCLUDED.status,
+  progress_percentage = EXCLUDED.progress_percentage,
+  priority = EXCLUDED.priority,
+  updated_at = NOW();
+
+-- Align session feedback data with ratings for richer analytics
+INSERT INTO session_feedback (id, session_id, client_id, coach_id, overall_rating, communication_rating, helpfulness_rating, preparation_rating, feedback_text, would_recommend, created_at, updated_at)
+VALUES
+  ('aa0e8400-e29b-41d4-a716-446655440001', '660e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440011', '550e8400-e29b-41d4-a716-446655440001', 5, 5, 5, 4, 'Felt fully supported throughout the session.', true, NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
+  ('aa0e8400-e29b-41d4-a716-446655440002', '660e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440012', '550e8400-e29b-41d4-a716-446655440001', 4, 4, 5, 4, 'Clear action plan for the next month.', true, NOW() - INTERVAL '4 days', NOW() - INTERVAL '4 days'),
+  ('aa0e8400-e29b-41d4-a716-446655440003', '660e8400-e29b-41d4-a716-446655440003', '550e8400-e29b-41d4-a716-446655440013', '550e8400-e29b-41d4-a716-446655440002', 5, 5, 5, 5, 'Incredibly insightful discussion.', true, NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day'),
+  ('aa0e8400-e29b-41d4-a716-446655440004', '660e8400-e29b-41d4-a716-446655440007', '550e8400-e29b-41d4-a716-446655440011', '550e8400-e29b-41d4-a716-446655440001', 4, 4, 4, 4, 'Great accountability check-in.', true, NOW() - INTERVAL '9 days', NOW() - INTERVAL '9 days'),
+  ('aa0e8400-e29b-41d4-a716-446655440005', '660e8400-e29b-41d4-a716-446655440008', '550e8400-e29b-41d4-a716-446655440012', '550e8400-e29b-41d4-a716-446655440002', 5, 5, 4, 5, 'Focused on the right strategic priorities.', true, NOW() - INTERVAL '14 days', NOW() - INTERVAL '14 days'),
+  ('aa0e8400-e29b-41d4-a716-446655440006', '660e8400-e29b-41d4-a716-446655440009', '550e8400-e29b-41d4-a716-446655440014', '550e8400-e29b-41d4-a716-446655440003', 4, 4, 4, 4, 'Celebrated big milestone wins together.', true, NOW() - INTERVAL '19 days', NOW() - INTERVAL '19 days'),
+  ('aa0e8400-e29b-41d4-a716-446655440007', '660e8400-e29b-41d4-a716-446655440010', '550e8400-e29b-41d4-a716-446655440015', '550e8400-e29b-41d4-a716-446655440001', 5, 5, 5, 5, 'Left with a clear tactical plan.', true, NOW() - INTERVAL '24 days', NOW() - INTERVAL '24 days')
+ON CONFLICT (session_id, client_id) DO UPDATE SET
+  overall_rating = EXCLUDED.overall_rating,
+  communication_rating = EXCLUDED.communication_rating,
+  helpfulness_rating = EXCLUDED.helpfulness_rating,
+  preparation_rating = EXCLUDED.preparation_rating,
+  feedback_text = EXCLUDED.feedback_text,
+  would_recommend = EXCLUDED.would_recommend,
+  updated_at = NOW();
+
 -- Verify the test data
 SELECT 
   'Users Summary' as summary,

--- a/supabase/tests/coach_dashboard_schema.sql
+++ b/supabase/tests/coach_dashboard_schema.sql
@@ -1,0 +1,44 @@
+-- Coach Dashboard Schema Verification
+-- -----------------------------------
+-- These queries help confirm that the critical tables used by the coach dashboard
+-- (notes, goals, feedback, and profiles) exist with the expected columns and
+-- security settings. Run this script against your Supabase/Postgres instance to
+-- quickly validate that migrations were applied correctly.
+
+-- 1. Ensure the required tables are present
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN ('coach_notes', 'client_goals', 'session_feedback', 'session_ratings', 'coach_profiles')
+ORDER BY table_name;
+
+-- 2. Inspect key columns for each table
+SELECT table_name, column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name IN ('coach_notes', 'client_goals', 'session_feedback', 'session_ratings', 'coach_profiles')
+ORDER BY table_name, ordinal_position;
+
+-- 3. Confirm row-level security is enabled on every table the dashboard reads
+SELECT
+  relname AS table_name,
+  relrowsecurity AS rls_enabled
+FROM pg_class
+WHERE relname IN ('coach_notes', 'client_goals', 'session_feedback', 'session_ratings', 'coach_profiles')
+ORDER BY relname;
+
+-- 4. Verify the updated_at triggers exist so analytics always receive fresh data
+SELECT
+  t.tgname AS trigger_name,
+  c.relname AS table_name
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+WHERE t.tgenabled = 'O'
+  AND c.relname IN ('coach_notes', 'client_goals', 'session_feedback', 'session_ratings', 'coach_profiles')
+ORDER BY c.relname, t.tgname;
+
+-- 5. Double-check that goal progress metrics have sane bounds
+SELECT
+  MIN(progress_percentage) AS min_progress,
+  MAX(progress_percentage) AS max_progress
+FROM client_goals;


### PR DESCRIPTION
## Summary
- replace placeholder coach dashboard stats with session-aware revenue, client activity, and rating calculations that read from Supabase feedback tables
- surface real client insights by enriching the clients list and client detail APIs with goal, feedback, and status data plus a shared helper for resolving per-coach session rates
- seed analytics fixtures and add a schema verification script so dashboards have consistent coach profile, goal, and feedback data

## Testing
- pnpm next lint --dir src/app/api/coach --dir src/components/dashboard/coach --dir src/lib/coach-dashboard

------
https://chatgpt.com/codex/tasks/task_e_68e4cc0206e883208f35aabf46703228