### PR TITLE
Refactor auth client to use centralized config

### DIFF
--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -13,6 +13,10 @@ import { PasswordInput } from '@/components/ui/password-input';
 import { ArrowLeft, CheckCircle, AlertCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { commonValidators } from '@/lib/validation/common';
+import { config } from '@/lib/config';
+
+const AUTH_ENDPOINTS = config.endpoints.auth;
+const HTTP_CONFIG = config.http;
 
 // Schema for password reset request
 const resetRequestSchema = z.object({
@@ -62,9 +66,9 @@ export function ResetPasswordForm({ token, onBack, onSuccess }: ResetPasswordFor
     setError(null);
 
     try {
-      const response = await fetch('/api/auth/reset-password', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch(AUTH_ENDPOINTS.RESET_PASSWORD, {
+        method: HTTP_CONFIG.methods.POST,
+        headers: { 'Content-Type': HTTP_CONFIG.contentTypes.JSON },
         body: JSON.stringify(data),
       });
 
@@ -107,9 +111,9 @@ export function ResetPasswordForm({ token, onBack, onSuccess }: ResetPasswordFor
     setError(null);
 
     try {
-      const response = await fetch('/api/auth/update-password', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch(AUTH_ENDPOINTS.UPDATE_PASSWORD, {
+        method: HTTP_CONFIG.methods.POST,
+        headers: { 'Content-Type': HTTP_CONFIG.contentTypes.JSON },
         body: JSON.stringify({
           password: data.password,
           token,


### PR DESCRIPTION
## Summary
- refactor the shared auth API client to resolve all endpoints through the centralized configuration module and normalize headers
- update the reset password form to fetch using the centralized auth endpoint and HTTP configuration helpers

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e526ca4f208320b7e9f65c0c9bb2e4