### PR TITLE
fix: skip pre-start weekdays in recurrence planner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Loom Coaching Platform - Environment Configuration Example
+# ---------------------------------------------------------
+# Copy this file to `.env.local` and replace the placeholder values with the
+# credentials from your Supabase project and deployment environment.
+
+# Supabase project configuration (required for both client and server usage)
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Public application metadata
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Server-side credentials (DO NOT commit real values)
+SUPABASE_SERVICE_ROLE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+
+# Supabase storage configuration for task attachments
+TASK_ATTACHMENTS_BUCKET=task-attachments

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
 ## ✨ Features
 
 ### 🎨 Modern Design System
+
 - **Professional SaaS Aesthetic**: Clean, light backgrounds with sophisticated dark accents
 - **Orange & Red Color Scheme**: Primary colors using dark orange (#ea580c) and red (#ef4444)
 - **Thin Typography**: Inter font with light weights (300/200) for a professional look
@@ -12,6 +13,7 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
 - **Responsive Design**: Mobile-first approach with beautiful animations
 
 ### 🔐 Authentication System
+
 - **Modern Sign In/Up Pages**: Redesigned with new design system
 - **Multi-Factor Authentication (MFA)**: Enhanced security features
 - **Password Reset Flow**: Professional reset process with email verification
@@ -19,6 +21,7 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
 - **Internationalization**: English and Hebrew language support
 
 ### 🧩 Component Library
+
 - **Buttons**: Orange primary, black secondary, red accent variants
 - **Form Inputs**: Clean styling with orange focus states
 - **Tables**: Professional data display with hover effects
@@ -27,6 +30,7 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
 - **Design System Showcase**: Complete component library at `/design-system`
 
 ### 🛠 Tech Stack
+
 - **Frontend**: Next.js 15 with React 19, TypeScript
 - **Styling**: Tailwind CSS 4 with custom design tokens
 - **UI Components**: Radix UI primitives with custom styling
@@ -39,18 +43,30 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
 ## 🚀 Getting Started
 
 ### Prerequisites
-- Node.js 18+ 
+
+- Node.js 18+
 - npm, yarn, pnpm, or bun
+
+### Contributor prerequisites checklist
+
+- [ ] Access to the shared Supabase project with the following secrets available locally and in CI: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` for server tasks.
+- [ ] Supabase CLI (optional but recommended) if you plan to inspect policies or run `supabase db` commands.
+- [ ] Firebase project credentials with Cloud Messaging enabled (service account JSON for workers and web push key for the client).
+- [ ] Redis instance URL (Upstash/Supabase/Redis Cloud) reserved for background queues – placeholder until the notification worker is implemented.
+- [ ] Confirmed access to Loom design assets and Figma references used by the dashboard modules.
+- [ ] Playwright browsers installed locally (`npx playwright install`) to execute the existing end-to-end suite.
 
 ### Installation
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/Tomerg91/Loom.git
    cd loom-app
    ```
 
 2. **Install dependencies**
+
    ```bash
    npm install
    # or
@@ -62,12 +78,14 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
    ```
 
 3. **Set up environment variables**
+
    ```bash
    cp .env.example .env.local
    # Edit .env.local with your configuration
    ```
 
 4. **Start the development server**
+
    ```bash
    npm run dev
    # or
@@ -94,11 +112,13 @@ A modern, professional coaching platform built with Next.js 15, featuring a beau
 ## 🧪 Testing & Development
 
 ### Design System Preview
+
 - **Test Auth Pages**: Open `test-auth-pages.html` in your browser
 - **Test Components**: Open `test-design-system.html` for component preview
 - **Live Showcase**: Visit `/design-system` when running the dev server
 
 ### Scripts Available
+
 ```bash
 npm run dev          # Start development server
 npm run build        # Build for production
@@ -112,6 +132,7 @@ npm run test:e2e     # Run Playwright tests
 ## 🎨 Design System
 
 ### Color Palette
+
 - **Primary Orange**: `#ea580c` (Dark orange for buttons)
 - **Orange**: `#f97316` (Standard orange)
 - **Red**: `#ef4444` (Accent and destructive actions)
@@ -119,12 +140,15 @@ npm run test:e2e     # Run Playwright tests
 - **Neutrals**: Gray scale from 50-950
 
 ### Typography
+
 - **Font Family**: Inter (Google Fonts)
 - **Weights**: Thin (100), Extralight (200), Light (300), Normal (400)
 - **Approach**: Light fonts for professional, clean appearance
 
 ### Components
+
 All components follow the design system principles:
+
 - Clean white backgrounds
 - Subtle shadows and borders
 - Orange focus states

--- a/docs/action-items-homework-implementation-plan.md
+++ b/docs/action-items-homework-implementation-plan.md
@@ -1,0 +1,81 @@
+# Action Items & Homework Implementation Plan Notes
+
+## Step 1 – Platform Audit (Completed)
+
+### Next.js & Supabase Configuration Overview
+
+- The application runs on **Next.js 15** with the App Router enabled and strict mode active (`next.config.js`). Performance optimizations include optimized package imports and Turbopack rules for SVG assets.
+- Supabase access is centralized in `src/lib/supabase/client.ts` and `src/lib/supabase/server.ts`. Both modules validate `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` at runtime and expose singleton clients to avoid redundant GoTrue sessions.
+- Server-side administration uses `createAdminClient`, which depends on `SUPABASE_SERVICE_ROLE_KEY`. This key is optional in `src/env/index.ts`, so any feature requiring privileged Supabase calls (e.g., background migrations) must verify the variable before use.
+- Environment handling is consolidated through `@t3-oss/env-nextjs` (`src/env/index.ts`). The helper already maps new Supabase environment names (`SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`) to the expected Next.js variables, reducing friction for local vs. hosted setups.
+
+### Authentication Patterns Confirmed
+
+- Authentication flows rely on `AuthService` (`src/lib/auth/auth.ts`), which constructs either a server or client Supabase instance and caches user profiles fetched through `createUserService`.
+- The service supplements Supabase session data with additional profile metadata (role, onboarding status, MFA flags) and manages session refresh with retry logic and forced sign-out when tokens become invalid.
+- Middleware and client hooks (`src/lib/auth/middleware.ts`, `src/lib/auth/use-auth.ts`) wrap these services to enforce role-based routing. Route handlers and server components should continue to use `AuthService.create(true)` to respect cache invalidation.
+
+### Reusable Coaching Components & Utilities
+
+- Coach-specific UI lives primarily in `src/components/dashboard/coach`, with supporting widgets in `src/components/dashboard/widgets` and shared layout primitives under `src/components/dashboard/shared`.
+- Scheduling and client relationship features already exist in `src/components/sessions` and `src/components/coach`, which will help shape task assignment experiences.
+- Supabase-aware hooks (`src/lib/hooks`), TanStack Query helpers (`src/lib/queries`), and permissions utilities (`src/lib/auth/permissions.ts`) provide a foundation for enforcing access in forthcoming task APIs.
+
+### Identified Gaps & Considerations for Upcoming Steps
+
+- **Database schema coverage**: Supabase tables for tasks, instances, progress updates, and notifications are absent; Step 3 must introduce them and regenerate the typed client definitions. Note that Supabase Database typings are currently “loose” in `server.ts`, signalling the need to resync generated types after migrations.
+- **Environment readiness**: Firebase credentials and Redis URL are not yet defined in `src/env/index.ts`. We will extend the schema when notification workers (Step 8) are implemented.
+- **Module scaffold**: There is no `/src/modules/tasks` directory yet. Step 2 will introduce the module structure and documentation to isolate domain logic from existing dashboards.
+- **Notification infrastructure**: While there is an existing notifications directory (`src/components/notifications`), background job orchestration is not configured. Future steps should align with the planned BullMQ worker.
+
+### Recommendations Before Proceeding to Step 2
+
+- Confirm that contributors possess Supabase service-role access as highlighted in the README checklist to prevent runtime failures in server-side actions.
+- Plan to regenerate Supabase type definitions immediately after Step 3 migrations to bring typings back in sync with the new task domain tables.
+
+## Step 2 – Tasks Module Scaffolding (Completed)
+
+- Created the `src/modules/tasks` workspace with dedicated subdirectories for `api`, `components`, `hooks`, `services`, and `types` so future features can be developed in isolation.
+- Documented module conventions, folder responsibilities, and roadmap alignment in `src/modules/tasks/README.md` to streamline onboarding and code reviews.
+- Added placeholder `index.ts` files in each subdirectory to establish public export hubs that will be expanded as APIs, UI, and services are implemented in later steps.
+
+## Step 3 – Supabase Schema & Migration (Completed)
+
+- Authored `supabase/migrations/20251001000000_add_tasks_domain.sql`, introducing enums for task priority, status, notification job type, and job status alongside normalized tables for categories, tasks, instances, progress updates, attachments, notification jobs, and export logs.
+- Established foreign-key relationships back to the existing `users` table, added timestamp triggers, and created supporting indexes so task queries remain performant for upcoming API work.
+- Documented the migration workflow: `supabase db push` (or `supabase db reset` locally) followed by `npm run supabase:types` to regenerate the typed client definitions that back the Next.js services.
+
+## Step 4 – Demo Seed Data (Completed)
+
+- Extended `supabase/seed.sql` with deterministic categories, tasks, instances, progress updates, and notification scaffolding so contributors can explore the new domain without manual inserts.
+- Updated the developer workflow to rely on Supabase tooling (`npm run db:seed`) which now proxies to `supabase db reset`, applying migrations and seeding in one step for local environments.
+- Highlighted how the seed data aligns with the implementation roadmap (e.g., one-off vs. recurring tasks) so testers can validate recurrence and filtering behaviour introduced in later steps.
+
+## Step 5 – Task CRUD API (Completed)
+
+- Implemented collection and item route handlers under `/api/tasks` using shared API utility wrappers to enforce authentication, coach-role authorization, and structured JSON responses.
+- Replaced the prior Prisma-centric service with a Supabase-backed `TaskService` that performs ownership checks, persists task metadata, orchestrates instance creation, and returns DTOs compatible with the frontend plan.
+- Maintained the Zod DTO schemas for payload validation and expanded permissions/tests to confirm the Supabase service paths handle success, validation failures, and authorization errors as expected.
+
+## Step 6 – Recurrence Scheduling Utilities (Completed)
+
+- Added a lightweight `RecurrenceService` that normalizes recurrence metadata and generates deterministic task instance schedules without relying on external runtime dependencies, keeping the feature compatible with constrained environments.
+- Integrated recurrence planning into the Supabase-backed `TaskService` so task creation and updates persist canonical rule metadata, regenerate upcoming instances, and keep the primary instance synchronized with due date changes.
+- Introduced shared recurrence schemas/types and unit coverage for the scheduling service so contributors can extend supported patterns with confidence.
+
+## Step 7 – Progress Updates & Attachments API (Completed)
+
+- Implemented the `/api/tasks/[taskId]/instances/[instanceId]/progress` endpoint, enabling authenticated clients and coaches to submit progress percentages, visibility preferences, and notes while the service layer enforces ownership, updates task instance status, and synchronizes parent task state.
+- Added a Supabase-backed `ProgressService` that persists progress records, stores attachment metadata, recalculates completion status, and safely rolls back when attachment inserts fail.
+- Created a signed-upload helper at `/api/attachments/sign` so authenticated users can request scoped Supabase Storage URLs; documented the new `TASK_ATTACHMENTS_BUCKET` environment variable in `.env.example` for bucket configuration.
+
+## Step Tracking
+
+- [x] Step 1: Audit existing codebase and align prerequisites (this document).
+- [x] Step 2: Establish domain-specific workspace.
+- [x] Step 3: Define Supabase schema extensions for tasks domain.
+- [x] Step 4: Seed reference data and helper scripts.
+- [x] Step 5: Implement task CRUD API route handlers.
+- [x] Step 6: Build recurrence scheduling utilities.
+- [x] Step 7: Create progress update and attachment APIs.
+- [ ] Steps 8-20: Pending as outlined in the implementation roadmap.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "supabase:types": "supabase gen types typescript --local > src/types/supabase.ts",
     "supabase:migration": "supabase migration new",
     "supabase:push": "supabase db push",
-    "db:seed": "supabase seed"
+    "db:seed": "supabase db reset"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/src/app/api/attachments/sign/route.ts
+++ b/src/app/api/attachments/sign/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+import { env } from '@/env';
+import {
+  HTTP_STATUS,
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequestBody,
+} from '@/lib/api/utils';
+import { config } from '@/lib/config';
+import { createAdminClient, createServerClient } from '@/lib/supabase/server';
+
+const signRequestSchema = z.object({
+  fileName: z
+    .string()
+    .min(1, 'File name is required')
+    .max(255, 'File name must be 255 characters or fewer'),
+  fileSize: z
+    .number({ invalid_type_error: 'File size must be a number' })
+    .int('File size must be an integer')
+    .min(1, 'File size must be greater than zero')
+    .max(
+      config.file.DOCUMENT_MAX_SIZE,
+      `File size must be ${config.file.DOCUMENT_MAX_SIZE} bytes or smaller`
+    ),
+  contentType: z
+    .string()
+    .min(1, 'Content type is required')
+    .max(120, 'Content type must be 120 characters or fewer'),
+});
+
+type AuthActor = { id: string; role: string };
+
+const createUnauthorizedResponse = () =>
+  createErrorResponse(
+    'Authentication required. Please sign in again.',
+    HTTP_STATUS.UNAUTHORIZED
+  );
+
+const sanitizeFileName = (fileName: string): string => {
+  const trimmed = fileName.trim();
+  if (!trimmed) {
+    return 'file';
+  }
+
+  const segments = trimmed.split('.');
+  const extension =
+    segments.length > 1 ? `.${segments.pop()!.toLowerCase()}` : '';
+  const base = segments.join('.');
+
+  const safeBase = base
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+
+  return `${safeBase || 'file'}${extension}`;
+};
+
+const resolveBucketName = () => {
+  try {
+    return (
+      env.TASK_ATTACHMENTS_BUCKET ||
+      process.env.NEXT_PUBLIC_TASK_ATTACHMENTS_BUCKET ||
+      'task-attachments'
+    );
+  } catch (error) {
+    // The env helper throws when server variables are accessed outside a
+    // server context (e.g., during isolated unit tests). Falling back to
+    // process.env keeps the handler usable in mocked environments while
+    // preserving runtime validation in production.
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn(
+        'Falling back to process.env for TASK_ATTACHMENTS_BUCKET',
+        error
+      );
+    }
+    return (
+      process.env.TASK_ATTACHMENTS_BUCKET ||
+      process.env.NEXT_PUBLIC_TASK_ATTACHMENTS_BUCKET ||
+      'task-attachments'
+    );
+  }
+};
+
+async function getAuthenticatedActor(): Promise<
+  { actor: AuthActor } | { response: Response }
+> {
+  try {
+    const supabase = createServerClient();
+    const { data: session, error } = await supabase.auth.getUser();
+
+    if (error || !session?.user) {
+      return { response: createUnauthorizedResponse() };
+    }
+
+    return {
+      actor: {
+        id: session.user.id,
+        role: session.user.role ?? 'client',
+      },
+    };
+  } catch (error) {
+    console.error('Attachment sign API authentication error:', error);
+    return { response: createUnauthorizedResponse() };
+  }
+}
+
+export const POST = async (request: NextRequest) => {
+  const authResult = await getAuthenticatedActor();
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { actor } = authResult;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    console.warn('Failed to parse attachment sign payload:', error);
+    return createErrorResponse('Invalid JSON body', HTTP_STATUS.BAD_REQUEST);
+  }
+
+  const parsed = validateRequestBody(signRequestSchema, body);
+
+  if (!parsed.success) {
+    return createErrorResponse(parsed.error, HTTP_STATUS.BAD_REQUEST);
+  }
+
+  const bucket = resolveBucketName();
+  const adminClient = createAdminClient();
+  const sanitizedName = sanitizeFileName(parsed.data.fileName);
+  const datePrefix = new Date().toISOString().slice(0, 10);
+  const objectPath = `${actor.id}/${datePrefix}/${randomUUID()}-${sanitizedName}`;
+
+  const { data: uploadData, error: uploadError } = await adminClient.storage
+    .from(bucket)
+    .createSignedUploadUrl(objectPath, { upsert: false });
+
+  if (uploadError || !uploadData?.signedUrl) {
+    console.error('Failed to create signed upload URL:', uploadError);
+    return createErrorResponse(
+      'Unable to generate upload URL. Please try again.',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+
+  const { data: publicUrlData } = adminClient.storage
+    .from(bucket)
+    .getPublicUrl(objectPath);
+
+  return createSuccessResponse(
+    {
+      uploadUrl: uploadData.signedUrl,
+      token: uploadData.token,
+      path: uploadData.path ?? objectPath,
+      bucket,
+      fileName: sanitizedName,
+      publicUrl: publicUrlData?.publicUrl ?? null,
+      fileSize: parsed.data.fileSize,
+      contentType: parsed.data.contentType,
+    },
+    'Signed upload URL generated successfully',
+    HTTP_STATUS.CREATED
+  );
+};

--- a/src/app/api/tasks/[taskId]/instances/[instanceId]/progress/route.ts
+++ b/src/app/api/tasks/[taskId]/instances/[instanceId]/progress/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import {
+  HTTP_STATUS,
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequestBody,
+} from '@/lib/api/utils';
+import { createServerClient } from '@/lib/supabase/server';
+import {
+  ProgressService,
+  ProgressServiceError,
+} from '@/modules/tasks/services/progress-service';
+import { createProgressUpdateSchema } from '@/modules/tasks/types/progress';
+
+const progressService = new ProgressService();
+
+const paramsSchema = z.object({
+  taskId: z.string().uuid('Invalid taskId parameter'),
+  instanceId: z.string().uuid('Invalid instanceId parameter'),
+});
+
+type TaskActorRole = 'coach' | 'admin' | 'client';
+
+type AuthActor = { id: string; role: string };
+
+type RouteContext = { params: Promise<{ taskId: string; instanceId: string }> };
+
+const mapRole = (role: string): TaskActorRole => {
+  if (role === 'coach' || role === 'admin' || role === 'client') {
+    return role;
+  }
+  return 'client';
+};
+
+const createUnauthorizedResponse = () =>
+  createErrorResponse(
+    'Authentication required. Please sign in again.',
+    HTTP_STATUS.UNAUTHORIZED
+  );
+
+async function getAuthenticatedActor(): Promise<
+  { actor: AuthActor } | { response: Response }
+> {
+  try {
+    const supabase = createServerClient();
+    const { data: session, error } = await supabase.auth.getUser();
+
+    if (error || !session?.user) {
+      return { response: createUnauthorizedResponse() };
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', session.user.id)
+      .single();
+
+    if (profileError) {
+      console.warn(
+        'Failed to fetch user profile for progress API:',
+        profileError.message
+      );
+    }
+
+    return {
+      actor: {
+        id: session.user.id,
+        role: profile?.role ?? 'client',
+      },
+    };
+  } catch (error) {
+    console.error('Progress API authentication error:', error);
+    return { response: createUnauthorizedResponse() };
+  }
+}
+
+export const POST = async (request: NextRequest, context: RouteContext) => {
+  const authResult = await getAuthenticatedActor();
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { actor } = authResult;
+  const { taskId, instanceId } = paramsSchema.parse(await context.params);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    console.warn('Failed to parse progress update payload:', error);
+    return createErrorResponse('Invalid JSON body', HTTP_STATUS.BAD_REQUEST);
+  }
+
+  const parsed = validateRequestBody(createProgressUpdateSchema, body);
+
+  if (!parsed.success) {
+    return createErrorResponse(parsed.error, HTTP_STATUS.BAD_REQUEST);
+  }
+
+  try {
+    const progress = await progressService.createProgressUpdate(
+      { id: actor.id, role: mapRole(actor.role) },
+      {
+        taskId,
+        taskInstanceId: instanceId,
+        input: parsed.data,
+      }
+    );
+
+    return createSuccessResponse(
+      progress,
+      'Progress update recorded successfully',
+      HTTP_STATUS.CREATED
+    );
+  } catch (error) {
+    if (error instanceof ProgressServiceError) {
+      return createErrorResponse(error.message, error.status);
+    }
+
+    console.error('Progress update error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+};

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import {
+  HTTP_STATUS,
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequestBody,
+} from '@/lib/api/utils';
+import { createServerClient } from '@/lib/supabase/server';
+import {
+  TaskService,
+  TaskServiceError,
+} from '@/modules/tasks/services/task-service';
+import { updateTaskSchema } from '@/modules/tasks/types/task';
+
+const taskService = new TaskService();
+
+const paramsSchema = z.object({
+  taskId: z.string().uuid('Invalid taskId parameter'),
+});
+
+type TaskActorRole = 'coach' | 'admin' | 'client';
+
+function mapRole(role: string): TaskActorRole {
+  if (role === 'coach' || role === 'admin' || role === 'client') {
+    return role;
+  }
+  return 'client';
+}
+
+type RouteContext = {
+  params: Promise<{ taskId: string }>;
+};
+
+type AuthActor = { id: string; role: string };
+
+const createUnauthorizedResponse = () =>
+  createErrorResponse(
+    'Authentication required. Please sign in again.',
+    HTTP_STATUS.UNAUTHORIZED
+  );
+
+async function getAuthenticatedActor(): Promise<
+  { actor: AuthActor } | { response: Response }
+> {
+  try {
+    const supabase = createServerClient();
+    const { data: session, error } = await supabase.auth.getUser();
+
+    if (error || !session?.user) {
+      return { response: createUnauthorizedResponse() };
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', session.user.id)
+      .single();
+
+    if (profileError) {
+      console.warn(
+        'Failed to fetch user profile for task route:',
+        profileError.message
+      );
+    }
+
+    return {
+      actor: {
+        id: session.user.id,
+        role: profile?.role ?? 'client',
+      },
+    };
+  } catch (error) {
+    console.error('Task item API authentication error:', error);
+    return { response: createUnauthorizedResponse() };
+  }
+}
+
+export const GET = async (_request: NextRequest, context: RouteContext) => {
+  const authResult = await getAuthenticatedActor();
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { actor } = authResult;
+  const { taskId } = paramsSchema.parse(await context.params);
+
+  try {
+    const task = await taskService.getTaskById(taskId, {
+      id: actor.id,
+      role: mapRole(actor.role),
+    });
+    return createSuccessResponse(task);
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      return createErrorResponse(error.message, error.status);
+    }
+    console.error('Task retrieval error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+export const PATCH = async (request: NextRequest, context: RouteContext) => {
+  const authResult = await getAuthenticatedActor();
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { actor } = authResult;
+
+  if (actor.role !== 'coach' && actor.role !== 'admin') {
+    return createErrorResponse(
+      'Access denied. Required role: coach',
+      HTTP_STATUS.FORBIDDEN
+    );
+  }
+
+  const { taskId } = paramsSchema.parse(await context.params);
+  const body = await request.json();
+  const parsed = validateRequestBody(updateTaskSchema, body);
+
+  if (!parsed.success) {
+    return createErrorResponse(parsed.error, HTTP_STATUS.BAD_REQUEST);
+  }
+
+  try {
+    const task = await taskService.updateTask(
+      taskId,
+      { id: actor.id, role: mapRole(actor.role) },
+      parsed.data
+    );
+    return createSuccessResponse(task, 'Task updated successfully');
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      return createErrorResponse(error.message, error.status);
+    }
+    console.error('Task update error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+};

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest } from 'next/server';
+
+import {
+  HTTP_STATUS,
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequestBody,
+} from '@/lib/api/utils';
+import { createServerClient } from '@/lib/supabase/server';
+import {
+  TaskService,
+  TaskServiceError,
+} from '@/modules/tasks/services/task-service';
+import {
+  createTaskSchema,
+  taskListQuerySchema,
+  type TaskListQueryInput,
+} from '@/modules/tasks/types/task';
+
+const taskService = new TaskService();
+
+type AuthActor = {
+  id: string;
+  role: string;
+};
+
+const createUnauthorizedResponse = () =>
+  createErrorResponse(
+    'Authentication required. Please sign in again.',
+    HTTP_STATUS.UNAUTHORIZED
+  );
+
+async function getAuthenticatedActor(): Promise<
+  { actor: AuthActor } | { response: Response }
+> {
+  try {
+    const supabase = createServerClient();
+    const { data: session, error } = await supabase.auth.getUser();
+
+    if (error || !session?.user) {
+      return { response: createUnauthorizedResponse() };
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', session.user.id)
+      .single();
+
+    if (profileError) {
+      console.warn(
+        'Failed to fetch user profile for tasks API:',
+        profileError.message
+      );
+    }
+
+    return {
+      actor: {
+        id: session.user.id,
+        role: profile?.role ?? 'client',
+      },
+    };
+  } catch (error) {
+    console.error('Task API authentication error:', error);
+    return { response: createUnauthorizedResponse() };
+  }
+}
+
+export const GET = async (request: NextRequest) => {
+  const authResult = await getAuthenticatedActor();
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { actor } = authResult;
+
+  if (actor.role !== 'coach' && actor.role !== 'admin') {
+    return createErrorResponse(
+      'Access denied. Required role: coach',
+      HTTP_STATUS.FORBIDDEN
+    );
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const statusParams = searchParams.getAll('status').filter(Boolean);
+  const priorityParams = searchParams.getAll('priority').filter(Boolean);
+
+  const rawQuery = {
+    coachId: searchParams.get('coachId') || undefined,
+    clientId: searchParams.get('clientId') || undefined,
+    categoryId: searchParams.get('categoryId') || undefined,
+    status: statusParams.length ? statusParams : undefined,
+    priority: priorityParams.length ? priorityParams : undefined,
+    includeArchived: searchParams.get('includeArchived') || undefined,
+    search: searchParams.get('search') || undefined,
+    dueDateFrom: searchParams.get('dueDateFrom') || undefined,
+    dueDateTo: searchParams.get('dueDateTo') || undefined,
+    sort: searchParams.get('sort') || undefined,
+    sortOrder: searchParams.get('sortOrder') || undefined,
+    page: searchParams.get('page') || undefined,
+    pageSize: searchParams.get('pageSize') || undefined,
+  };
+
+  const parsedQuery = taskListQuerySchema.safeParse(rawQuery);
+
+  if (!parsedQuery.success) {
+    return createErrorResponse('Validation failed', HTTP_STATUS.BAD_REQUEST);
+  }
+
+  const normalizedFilters: TaskListQueryInput = {
+    ...parsedQuery.data,
+    coachId: actor.role === 'coach' ? actor.id : parsedQuery.data.coachId,
+  };
+
+  try {
+    const result = await taskService.listTasks(
+      { id: actor.id, role: actor.role as 'coach' | 'admin' | 'client' },
+      normalizedFilters
+    );
+
+    return createSuccessResponse(result);
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      return createErrorResponse(error.message, error.status);
+    }
+    console.error('Task list error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+export const POST = async (request: NextRequest) => {
+  const authResult = await getAuthenticatedActor();
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { actor } = authResult;
+
+  if (actor.role !== 'coach' && actor.role !== 'admin') {
+    return createErrorResponse(
+      'Access denied. Required role: coach',
+      HTTP_STATUS.FORBIDDEN
+    );
+  }
+
+  const body = await request.json();
+  const parsed = validateRequestBody(createTaskSchema, body);
+
+  if (!parsed.success) {
+    return createErrorResponse(parsed.error, HTTP_STATUS.BAD_REQUEST);
+  }
+
+  const payload = {
+    ...parsed.data,
+    coachId: actor.role === 'coach' ? actor.id : parsed.data.coachId,
+  };
+
+  try {
+    const task = await taskService.createTask(
+      { id: actor.id, role: actor.role as 'coach' | 'admin' | 'client' },
+      payload
+    );
+
+    return createSuccessResponse(
+      task,
+      'Task created successfully',
+      HTTP_STATUS.CREATED
+    );
+  } catch (error) {
+    if (error instanceof TaskServiceError) {
+      return createErrorResponse(error.message, error.status);
+    }
+    console.error('Task creation error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+};

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -11,6 +11,7 @@ export const env = createEnv({
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
     DATABASE_URL: z.string().url().optional(),
     SENTRY_DSN: z.string().optional(),
+    TASK_ATTACHMENTS_BUCKET: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
@@ -19,12 +20,17 @@ export const env = createEnv({
   },
   runtimeEnv: {
     // Prefer new Supabase key names if present
-    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+    SUPABASE_SERVICE_ROLE_KEY:
+      process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
     DATABASE_URL: process.env.DATABASE_URL,
     SENTRY_DSN: process.env.SENTRY_DSN,
+    TASK_ATTACHMENTS_BUCKET: process.env.TASK_ATTACHMENTS_BUCKET,
     // Allow SUPABASE_URL (new naming) to satisfy NEXT_PUBLIC_SUPABASE_URL
-    NEXT_PUBLIC_SUPABASE_URL: process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.SUPABASE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_SUPABASE_URL:
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY:
+      process.env.SUPABASE_PUBLISHABLE_KEY ||
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   },
 });

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ZodError, ZodSchema } from 'zod';
-import type { ApiResponse, ApiError } from './types';
+
+import {
+  requirePermission as requirePermissionCheck,
+  canAccessResource,
+  type Permission,
+  type Role,
+} from '@/lib/auth/permissions';
+import { config } from '@/lib/config';
 import { createClient } from '@/lib/supabase/server';
 import type { Database } from '@/types/supabase';
-import { config } from '@/lib/config';
-import { requirePermission as requirePermissionCheck, canAccessResource, type Permission, type Role } from '@/lib/auth/permissions';
+
+import type { ApiResponse, ApiError } from './types';
 
 type UserRole = Database['public']['Tables']['users']['Row']['role'];
 export type AuthenticatedUser = {
@@ -62,9 +69,7 @@ export function createErrorResponse(
   error: string | ApiError,
   status: number = HTTP_STATUS.BAD_REQUEST
 ): NextResponse {
-  const errorObj = typeof error === 'string' 
-    ? createApiError(error)
-    : error;
+  const errorObj = typeof error === 'string' ? createApiError(error) : error;
 
   return NextResponse.json(
     {
@@ -82,10 +87,7 @@ export function createSuccessResponse<T>(
   message?: string,
   status: number = HTTP_STATUS.OK
 ): NextResponse {
-  return NextResponse.json(
-    createApiResponse(data, message),
-    { status }
-  );
+  return NextResponse.json(createApiResponse(data, message), { status });
 }
 
 // Enhanced request validation with security measures
@@ -99,7 +101,7 @@ export function validateRequestBody<T>(
   } = {}
 ): { success: true; data: T } | { success: false; error: ApiError } {
   const { sanitize = true, maxDepth = 10, maxSize = 1024 * 1024 } = options;
-  
+
   try {
     // Check payload size
     const bodyStr = JSON.stringify(body);
@@ -113,7 +115,7 @@ export function validateRequestBody<T>(
         ),
       };
     }
-    
+
     // Check object depth to prevent DoS attacks
     if (checkObjectDepth(body, maxDepth) > maxDepth) {
       return {
@@ -125,13 +127,13 @@ export function validateRequestBody<T>(
         ),
       };
     }
-    
+
     // Sanitize input if requested
     let sanitizedBody = body;
     if (sanitize && typeof body === 'object' && body !== null) {
       sanitizedBody = sanitizeObject(body);
     }
-    
+
     const data = schema.parse(sanitizedBody);
     return { success: true, data };
   } catch (error) {
@@ -141,18 +143,16 @@ export function validateRequestBody<T>(
         issues: error.issues.map(issue => ({
           path: issue.path.join('.'),
           message: issue.message,
-          code: issue.code
+          code: issue.code,
         })),
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
-      
+
       return {
         success: false,
-        error: createApiError(
-          'Validation failed',
-          'VALIDATION_ERROR',
-          { issues: error.issues }
-        ),
+        error: createApiError('Validation failed', 'VALIDATION_ERROR', {
+          issues: error.issues,
+        }),
       };
     }
     return {
@@ -163,16 +163,20 @@ export function validateRequestBody<T>(
 }
 
 // Helper function to check object depth
-function checkObjectDepth(obj: unknown, maxDepth: number, currentDepth = 0): number {
+function checkObjectDepth(
+  obj: unknown,
+  maxDepth: number,
+  currentDepth = 0
+): number {
   if (currentDepth > maxDepth) return currentDepth;
   if (typeof obj !== 'object' || obj === null) return currentDepth;
-  
+
   let maxChildDepth = currentDepth;
   for (const value of Object.values(obj)) {
     const childDepth = checkObjectDepth(value, maxDepth, currentDepth + 1);
     maxChildDepth = Math.max(maxChildDepth, childDepth);
   }
-  
+
   return maxChildDepth;
 }
 
@@ -181,11 +185,11 @@ function sanitizeObject(obj: unknown): unknown {
   if (typeof obj !== 'object' || obj === null) {
     return sanitizeValue(obj);
   }
-  
+
   if (Array.isArray(obj)) {
     return obj.map(item => sanitizeObject(item));
   }
-  
+
   const sanitized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     // Sanitize property names to prevent prototype pollution
@@ -194,7 +198,7 @@ function sanitizeObject(obj: unknown): unknown {
       sanitized[sanitizedKey] = sanitizeObject(value);
     }
   }
-  
+
   return sanitized;
 }
 
@@ -210,7 +214,7 @@ function sanitizeValue(value: unknown): unknown {
       .trim()
       .substring(0, 10000); // Limit string length
   }
-  
+
   return value;
 }
 
@@ -221,12 +225,12 @@ function sanitizePropertyName(key: string): string | null {
   if (dangerousKeys.includes(key.toLowerCase())) {
     return null;
   }
-  
+
   // Only allow alphanumeric characters, underscores, and hyphens
   if (!/^[a-zA-Z0-9_-]+$/.test(key)) {
     return null;
   }
-  
+
   return key.substring(0, 100); // Limit key length
 }
 
@@ -258,8 +262,11 @@ export function parsePagination(query: Record<string, string | string[]>): {
 } {
   const page = Math.max(1, parseInt(query.page as string) || 1);
   const limit = Math.min(
-    config.api.MAX_PAGE_SIZE, 
-    Math.max(config.api.MIN_PAGE_SIZE, parseInt(query.limit as string) || config.api.DEFAULT_PAGE_SIZE)
+    config.api.MAX_PAGE_SIZE,
+    Math.max(
+      config.api.MIN_PAGE_SIZE,
+      parseInt(query.limit as string) || config.api.DEFAULT_PAGE_SIZE
+    )
   );
   const offset = (page - 1) * limit;
 
@@ -271,7 +278,8 @@ export function parseSort(query: Record<string, string | string[]>): {
   sortOrder: 'asc' | 'desc';
 } {
   const sortBy = query.sortBy as string;
-  const sortOrder = (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc';
+  const sortOrder =
+    (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc';
 
   return { sortBy, sortOrder };
 }
@@ -285,14 +293,14 @@ export function withErrorHandling<T extends unknown[]>(
       return await handler(...args);
     } catch (error) {
       console.error('API Error:', error);
-      
+
       if (error instanceof Error) {
         return createErrorResponse(
           error.message,
           HTTP_STATUS.INTERNAL_SERVER_ERROR
         );
       }
-      
+
       return createErrorResponse(
         'An unexpected error occurred',
         HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -302,13 +310,19 @@ export function withErrorHandling<T extends unknown[]>(
 }
 
 // Request logging wrapper with correlation ID
-export function withRequestLogging<T extends [NextRequest, ...any[]]>(
-  handler: (...args: T) => Promise<NextResponse>,
+export function withRequestLogging(
+  handler: (request: NextRequest, ...args: unknown[]) => Promise<NextResponse>,
   opts: { name?: string } = {}
 ) {
-  return async (request: NextRequest, ...rest: any[]): Promise<NextResponse> => {
+  return async (
+    request: NextRequest,
+    ...rest: unknown[]
+  ): Promise<NextResponse> => {
     const enabled = process.env.LOG_REQUESTS === 'true';
-    const id = (request.headers.get('x-request-id') as string) || crypto.randomUUID?.() || Math.random().toString(36).slice(2);
+    const id =
+      (request.headers.get('x-request-id') as string) ||
+      crypto.randomUUID?.() ||
+      Math.random().toString(36).slice(2);
     const start = Date.now();
     if (enabled) {
       console.info('[API REQ]', {
@@ -316,7 +330,10 @@ export function withRequestLogging<T extends [NextRequest, ...any[]]>(
         name: opts.name || 'handler',
         method: request.method,
         url: request.nextUrl.pathname + (request.nextUrl.search || ''),
-        ip: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
+        ip:
+          request.headers.get('x-forwarded-for') ||
+          request.headers.get('x-real-ip') ||
+          'unknown',
         ua: request.headers.get('user-agent') || '',
       });
     }
@@ -347,10 +364,17 @@ export function withRequestLogging<T extends [NextRequest, ...any[]]>(
 }
 
 // Authentication helpers
-export function requireAuth<T extends unknown[]>(
-  handler: (user: AuthenticatedUser, request: NextRequest, ...args: T) => Promise<NextResponse>
+export function requireAuth(
+  handler: (
+    user: AuthenticatedUser,
+    request: NextRequest,
+    ...args: unknown[]
+  ) => Promise<NextResponse>
 ) {
-  return async (request: NextRequest, ...args: T): Promise<NextResponse> => {
+  return async (
+    request: NextRequest,
+    ...args: unknown[]
+  ): Promise<NextResponse> => {
     try {
       const supabase = await createClient();
       const authHeader = request.headers.get('authorization');
@@ -389,7 +413,7 @@ export function requireAuth<T extends unknown[]>(
           console.warn('Authentication failed:', {
             error: error.message,
             timestamp: new Date().toISOString(),
-            ip: request.headers.get('x-forwarded-for') || 'unknown'
+            ip: request.headers.get('x-forwarded-for') || 'unknown',
           });
 
           return createErrorResponse(
@@ -401,13 +425,14 @@ export function requireAuth<T extends unknown[]>(
         authUser = data.user as SupabaseUser;
         sessionExpiresAt = authUser?.exp ? authUser.exp * 1000 : null;
       } else {
-        const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+        const { data: sessionData, error: sessionError } =
+          await supabase.auth.getSession();
 
         if (sessionError) {
           console.warn('Session lookup failed:', {
             error: sessionError.message,
             timestamp: new Date().toISOString(),
-            ip: request.headers.get('x-forwarded-for') || 'unknown'
+            ip: request.headers.get('x-forwarded-for') || 'unknown',
           });
 
           return createErrorResponse(
@@ -454,7 +479,7 @@ export function requireAuth<T extends unknown[]>(
         console.warn('User profile lookup failed:', {
           userId: authUser.id,
           error: profileError.message,
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         });
 
         return createErrorResponse(
@@ -485,8 +510,12 @@ export function requireAuth<T extends unknown[]>(
         );
       }
 
-      const createdAt = (userProfile as { createdAt?: string }).createdAt || userProfile.created_at;
-      const accountAge = createdAt ? Date.now() - new Date(createdAt).getTime() : 0;
+      const createdAt =
+        (userProfile as { createdAt?: string }).createdAt ||
+        userProfile.created_at;
+      const accountAge = createdAt
+        ? Date.now() - new Date(createdAt).getTime()
+        : 0;
       if (accountAge < 0) {
         return createErrorResponse(
           'Invalid account creation date detected',
@@ -515,7 +544,7 @@ export function requireAuth<T extends unknown[]>(
       console.error('Authentication error:', {
         error: error instanceof Error ? error.message : 'Unknown error',
         timestamp: new Date().toISOString(),
-        ip: request.headers.get('x-forwarded-for') || 'unknown'
+        ip: request.headers.get('x-forwarded-for') || 'unknown',
       });
 
       return createErrorResponse(
@@ -537,42 +566,54 @@ const ROLE_HIERARCHY: Record<'admin' | 'coach' | 'client', number> = {
  * Generic factory for creating security middleware functions
  * Eliminates repetitive patterns in permission and access control
  */
-function createSecurityMiddleware<T extends unknown[]>(
-  checkFunction: (user: AuthenticatedUser, ...args: T) => boolean | Promise<boolean>,
-  errorMessage: (user: AuthenticatedUser, ...args: T) => string,
-  logContext: (user: AuthenticatedUser, ...args: T) => Record<string, any>
+function createSecurityMiddleware(
+  checkFunction: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => boolean | Promise<boolean>,
+  errorMessage: (user: AuthenticatedUser, ...args: unknown[]) => string,
+  logContext: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => Record<string, unknown>
 ) {
-  return function(
-    handler: (user: AuthenticatedUser, ...args: T) => Promise<Response | NextResponse>
+  return function (
+    handler: (
+      user: AuthenticatedUser,
+      ...args: unknown[]
+    ) => Promise<Response | NextResponse>
   ) {
-    return async (user: AuthenticatedUser, ...args: T): Promise<Response | NextResponse> => {
+    return async (
+      user: AuthenticatedUser,
+      ...args: unknown[]
+    ): Promise<Response | NextResponse> => {
       try {
         const hasAccess = await checkFunction(user, ...args);
-        
+
         if (!hasAccess) {
           const context = {
             userId: user.id,
             role: user.role,
             timestamp: new Date().toISOString(),
-            ...logContext(user, ...args)
+            ...logContext(user, ...args),
           };
-          
+
           console.warn('Access denied:', context);
-          
+
           return createErrorResponse(
             errorMessage(user, ...args),
             HTTP_STATUS.FORBIDDEN
           );
         }
-        
+
         // Log successful access for auditing
         console.debug('Access granted:', {
           userId: user.id,
           role: user.role,
           timestamp: new Date().toISOString(),
-          ...logContext(user, ...args)
+          ...logContext(user, ...args),
         });
-        
+
         return await handler(user, ...args);
       } catch (error) {
         console.warn('Security check failed:', {
@@ -580,9 +621,9 @@ function createSecurityMiddleware<T extends unknown[]>(
           role: user.role,
           error: error instanceof Error ? error.message : 'Unknown error',
           timestamp: new Date().toISOString(),
-          ...logContext(user, ...args)
+          ...logContext(user, ...args),
         });
-        
+
         return createErrorResponse(
           errorMessage(user, ...args),
           HTTP_STATUS.FORBIDDEN
@@ -607,7 +648,8 @@ export function requirePermission(requiredPermission: Permission) {
 // Resource-based permission checking using the factory
 export function requireResourceAccess(resource: string, action: string) {
   return createSecurityMiddleware(
-    (user: AuthenticatedUser) => canAccessResource(user.role as Role, resource, action),
+    (user: AuthenticatedUser) =>
+      canAccessResource(user.role as Role, resource, action),
     () => `Access denied. Cannot ${action} ${resource}`,
     () => ({ resource, action })
   );
@@ -617,48 +659,69 @@ export function requireResourceAccess(resource: string, action: string) {
 export function requireRole(requiredRole: UserRole) {
   return createSecurityMiddleware(
     (user: AuthenticatedUser) => {
-      const userLevel = ROLE_HIERARCHY[user.role as 'admin' | 'coach' | 'client'] ?? 0;
-      const requiredLevel = ROLE_HIERARCHY[requiredRole as 'admin' | 'coach' | 'client'] ?? Infinity;
+      const userLevel =
+        ROLE_HIERARCHY[user.role as 'admin' | 'coach' | 'client'] ?? 0;
+      const requiredLevel =
+        ROLE_HIERARCHY[requiredRole as 'admin' | 'coach' | 'client'] ??
+        Infinity;
       return userLevel >= requiredLevel;
     },
     () => `Access denied. Required role: ${requiredRole}`,
-    (user) => ({ userRole: user.role, requiredRole })
+    user => ({ userRole: user.role, requiredRole })
   );
 }
 
 // Specific role requirement helpers (updated to use new permission system)
-export function requireAdmin<T extends unknown[]>(
-  handler: (user: AuthenticatedUser, ...args: T) => Promise<NextResponse>
+export function requireAdmin(
+  handler: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => Promise<NextResponse>
 ) {
   return requirePermission('admin:read')(handler);
 }
 
-export function requireCoach<T extends unknown[]>(
-  handler: (user: AuthenticatedUser, ...args: T) => Promise<NextResponse>
+export function requireCoach(
+  handler: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => Promise<NextResponse>
 ) {
   return requirePermission('coach:read')(handler);
 }
 
-export function requireClient<T extends unknown[]>(
-  handler: (user: AuthenticatedUser, ...args: T) => Promise<NextResponse>
+export function requireClient(
+  handler: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => Promise<NextResponse>
 ) {
   return requirePermission('client:read')(handler);
 }
 
 // Ownership-based access control
-export function requireOwnership<T extends unknown[]>(
-  handler: (user: AuthenticatedUser, ...args: T) => Promise<NextResponse>,
-  getOwnerId: (user: AuthenticatedUser, ...args: T) => Promise<string | null>
+export function requireOwnership(
+  handler: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => Promise<NextResponse>,
+  getOwnerId: (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ) => Promise<string | null>
 ) {
-  return async (user: AuthenticatedUser, ...args: T): Promise<NextResponse> => {
+  return async (
+    user: AuthenticatedUser,
+    ...args: unknown[]
+  ): Promise<NextResponse> => {
     try {
       const ownerId = await getOwnerId(user, ...args);
-      
+
       // Allow access if user is the owner or has admin role
       if (user.id === ownerId || user.role === 'admin') {
         return await handler(user, ...args);
       }
-      
+
       // For coaches, allow access to their clients' resources
       if (user.role === 'coach' && ownerId) {
         const supabase = await createClient();
@@ -668,19 +731,19 @@ export function requireOwnership<T extends unknown[]>(
           .eq('coach_id', user.id)
           .eq('client_id', ownerId)
           .limit(1);
-          
+
         if (hasAccess && hasAccess.length > 0) {
           return await handler(user, ...args);
         }
       }
-      
+
       console.warn('Ownership access denied:', {
         userId: user.id,
         role: user.role,
         ownerId,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
-      
+
       return createErrorResponse(
         'Access denied. You can only access your own resources.',
         HTTP_STATUS.FORBIDDEN
@@ -689,9 +752,9 @@ export function requireOwnership<T extends unknown[]>(
       console.error('Ownership check failed:', {
         userId: user.id,
         error: error instanceof Error ? error.message : 'Unknown error',
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
-      
+
       return createErrorResponse(
         'Access denied due to ownership verification failure',
         HTTP_STATUS.FORBIDDEN
@@ -701,12 +764,15 @@ export function requireOwnership<T extends unknown[]>(
 }
 
 // Enhanced rate limiting with security features
-const rateLimitMap = new Map<string, { count: number; resetTime: number; suspiciousActivity: boolean }>();
+const rateLimitMap = new Map<
+  string,
+  { count: number; resetTime: number; suspiciousActivity: boolean }
+>();
 const blockedIPs = new Set<string>();
 const MAX_MAP_SIZE = 10000; // Prevent memory exhaustion
 
 export function rateLimit(
-  maxRequests: number = 100, 
+  maxRequests: number = 100,
   windowMs: number = 60000,
   options: {
     skipSuccessfulRequests?: boolean;
@@ -715,30 +781,30 @@ export function rateLimit(
     enableSuspiciousActivityDetection?: boolean;
   } = {}
 ) {
-  const { 
+  const {
     skipSuccessfulRequests = false,
     skipFailedRequests = false,
     blockDuration = 15 * 60 * 1000, // 15 minutes
-    enableSuspiciousActivityDetection = true
+    enableSuspiciousActivityDetection = true,
   } = options;
-  
-  return function<T extends unknown[]>(
+
+  return function <T extends unknown[]>(
     handler: (request: NextRequest, ...args: T) => Promise<NextResponse>
   ) {
     return async (request: NextRequest, ...args: T): Promise<NextResponse> => {
       const ip = getClientIP(request);
       const now = Date.now();
       const key = `${ip}:${request.nextUrl.pathname}`;
-      
+
       // Check if IP is blocked
       if (blockedIPs.has(ip)) {
         console.warn('Blocked IP attempted access:', {
           ip,
           path: request.nextUrl.pathname,
           userAgent: request.headers.get('user-agent'),
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         });
-        
+
         return createErrorResponse(
           'Access temporarily blocked due to suspicious activity',
           HTTP_STATUS.TOO_MANY_REQUESTS
@@ -751,38 +817,39 @@ export function rateLimit(
         const expiredKeys = entries
           .filter(([, value]) => value.resetTime < now)
           .map(([key]) => key);
-          
+
         expiredKeys.forEach(key => rateLimitMap.delete(key));
-        
+
         // If still too large, remove oldest entries
         if (rateLimitMap.size > MAX_MAP_SIZE * 0.8) {
           const oldestKeys = entries
             .sort(([, a], [, b]) => a.resetTime - b.resetTime)
             .slice(0, Math.floor(MAX_MAP_SIZE * 0.2))
             .map(([key]) => key);
-            
+
           oldestKeys.forEach(key => rateLimitMap.delete(key));
         }
       }
 
       const current = rateLimitMap.get(key);
       if (!current || current.resetTime < now) {
-        rateLimitMap.set(key, { 
-          count: 1, 
-          resetTime: now + windowMs, 
-          suspiciousActivity: false 
+        rateLimitMap.set(key, {
+          count: 1,
+          resetTime: now + windowMs,
+          suspiciousActivity: false,
         });
       } else {
         current.count++;
-        
+
         // Detect suspicious activity patterns
         if (enableSuspiciousActivityDetection) {
-          const requestRate = current.count / ((now - (current.resetTime - windowMs)) / 1000);
-          if (requestRate > maxRequests / (windowMs / 1000) * 2) {
+          const requestRate =
+            current.count / ((now - (current.resetTime - windowMs)) / 1000);
+          if (requestRate > (maxRequests / (windowMs / 1000)) * 2) {
             current.suspiciousActivity = true;
           }
         }
-        
+
         if (current.count > maxRequests) {
           // Log rate limit violation
           console.warn('Rate limit exceeded:', {
@@ -793,59 +860,71 @@ export function rateLimit(
             windowMs,
             suspiciousActivity: current.suspiciousActivity,
             userAgent: request.headers.get('user-agent'),
-            timestamp: new Date().toISOString()
+            timestamp: new Date().toISOString(),
           });
-          
+
           // Block IP if showing suspicious activity
           if (current.suspiciousActivity && current.count > maxRequests * 2) {
             blockedIPs.add(ip);
             setTimeout(() => blockedIPs.delete(ip), blockDuration);
-            
+
             console.error('IP blocked due to excessive requests:', {
               ip,
               blockDuration: blockDuration / 1000 / 60,
-              timestamp: new Date().toISOString()
+              timestamp: new Date().toISOString(),
             });
           }
-          
+
           const response = createErrorResponse(
             'Too many requests. Please try again later.',
             HTTP_STATUS.TOO_MANY_REQUESTS
           );
-          
+
           // Add rate limit headers
           response.headers.set('X-RateLimit-Limit', maxRequests.toString());
           response.headers.set('X-RateLimit-Remaining', '0');
-          response.headers.set('X-RateLimit-Reset', Math.ceil(current.resetTime / 1000).toString());
-          response.headers.set('Retry-After', Math.ceil((current.resetTime - now) / 1000).toString());
-          
+          response.headers.set(
+            'X-RateLimit-Reset',
+            Math.ceil(current.resetTime / 1000).toString()
+          );
+          response.headers.set(
+            'Retry-After',
+            Math.ceil((current.resetTime - now) / 1000).toString()
+          );
+
           return response;
         }
       }
 
       // Execute the handler
       const response = await handler(request, ...args);
-      
+
       // Update rate limit based on response status
       const responseStatus = response.status;
       const currentEntry = rateLimitMap.get(key);
-      
+
       if (currentEntry) {
         // Don't count successful requests if configured
         if (skipSuccessfulRequests && responseStatus < 400) {
           currentEntry.count = Math.max(0, currentEntry.count - 1);
         }
-        
+
         // Don't count failed requests if configured
         if (skipFailedRequests && responseStatus >= 400) {
           currentEntry.count = Math.max(0, currentEntry.count - 1);
         }
-        
+
         // Add rate limit headers to successful responses
         if (responseStatus < 400) {
           response.headers.set('X-RateLimit-Limit', maxRequests.toString());
-          response.headers.set('X-RateLimit-Remaining', Math.max(0, maxRequests - currentEntry.count).toString());
-          response.headers.set('X-RateLimit-Reset', Math.ceil(currentEntry.resetTime / 1000).toString());
+          response.headers.set(
+            'X-RateLimit-Remaining',
+            Math.max(0, maxRequests - currentEntry.count).toString()
+          );
+          response.headers.set(
+            'X-RateLimit-Reset',
+            Math.ceil(currentEntry.resetTime / 1000).toString()
+          );
         }
       }
 
@@ -862,11 +941,11 @@ function getClientIP(request: NextRequest): string {
     'x-real-ip',
     'x-client-ip',
     'cf-connecting-ip', // Cloudflare
-    'x-forwarded', 
+    'x-forwarded',
     'forwarded-for',
-    'forwarded'
+    'forwarded',
   ];
-  
+
   for (const header of headers) {
     const value = request.headers.get(header);
     if (value) {
@@ -877,48 +956,54 @@ function getClientIP(request: NextRequest): string {
       }
     }
   }
-  
+
   // Fallback to connection IP or unknown
-  return (request as any).ip || 'unknown';
+  const requestWithIp = request as NextRequest & { ip?: string | undefined };
+  return requestWithIp.ip ?? 'unknown';
 }
 
 // Helper function to validate IP address format
 function isValidIP(ip: string): boolean {
   // Basic IPv4 and IPv6 validation
-  const ipv4Regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+  const ipv4Regex =
+    /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
   const ipv6Regex = /^(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$/;
-  
+
   return ipv4Regex.test(ip) || ipv6Regex.test(ip);
 }
 
 // CORS helpers with environment-aware origin validation
 function getAllowedOrigins(): string[] {
   const isDevelopment = process.env.NODE_ENV === 'development';
-  const customOrigins = process.env.ALLOWED_ORIGINS?.split(',').map(origin => origin.trim()) || [];
-  
+  const customOrigins =
+    process.env.ALLOWED_ORIGINS?.split(',').map(origin => origin.trim()) || [];
+
   if (isDevelopment) {
     // Allow localhost in development
     return [
       'http://localhost:3000',
-      'http://localhost:3001', 
+      'http://localhost:3001',
       'http://127.0.0.1:3000',
-      ...customOrigins
+      ...customOrigins,
     ];
   }
-  
+
   // Production origins
   const productionOrigins = [
     'https://loom-app.vercel.app',
     'https://www.loom-app.com',
-    ...customOrigins
+    ...customOrigins,
   ];
-  
+
   return productionOrigins.filter(Boolean);
 }
 
-export function withCors(response: NextResponse, origin?: string): NextResponse {
+export function withCors(
+  response: NextResponse,
+  origin?: string
+): NextResponse {
   const allowedOrigins = getAllowedOrigins();
-  
+
   // Validate origin against allowed list
   let allowedOrigin = '';
   if (origin && allowedOrigins.includes(origin)) {
@@ -927,16 +1012,22 @@ export function withCors(response: NextResponse, origin?: string): NextResponse 
     // Use first allowed origin as default (usually main domain)
     allowedOrigin = allowedOrigins[0];
   }
-  
+
   if (allowedOrigin) {
     response.headers.set('Access-Control-Allow-Origin', allowedOrigin);
   }
-  
-  response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-  response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+
+  response.headers.set(
+    'Access-Control-Allow-Methods',
+    'GET, POST, PUT, DELETE, OPTIONS'
+  );
+  response.headers.set(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization, X-Requested-With'
+  );
   response.headers.set('Access-Control-Allow-Credentials', 'true');
   response.headers.set('Access-Control-Max-Age', '86400'); // 24 hours
-  
+
   return response;
 }
 

--- a/src/modules/tasks/README.md
+++ b/src/modules/tasks/README.md
@@ -1,0 +1,31 @@
+# Tasks Module
+
+This module centralizes task and homework functionality for both coaches and clients. It is designed to keep domain logic, API surface areas, UI primitives, and supporting utilities co-located so that future iterations can evolve independently from other product areas.
+
+## Folder Structure
+
+- `api/` – Client- and server-side request helpers, React Query hooks, and shared fetch utilities.
+- `components/` – React components dedicated to task management experiences (lists, forms, drawers, etc.).
+- `hooks/` – Custom React hooks used by task components for state management and side effects.
+- `services/` – Domain services encapsulating business logic (Supabase data accessors, recurrence utilities, notification helpers).
+- `types/` – Shared TypeScript definitions and schema validators.
+
+Each subdirectory exposes a local `index.ts` file to aggregate exports. When adding new modules, update the relevant index to maintain a clean public API for the tasks domain.
+
+## Contribution Guidelines
+
+1. Prefer colocating unit tests beside the implementation (e.g., `TaskFormModal.test.tsx`) when practical; otherwise use the existing `tests/` hierarchy for integration and end-to-end coverage.
+2. Keep API layer logic thin by delegating business rules to services. This promotes reuse between Next.js route handlers, React Query hooks, and background jobs.
+3. Export only stable interfaces from the root of each subdirectory to avoid breaking consumers unexpectedly. Re-export experimental utilities from feature-specific entry points instead.
+4. Update this README whenever the module structure changes so onboarding engineers understand the intended architecture.
+
+## Roadmap Alignment
+
+The scaffolding created in Step 2 supports upcoming milestones:
+
+- **Step 3:** Extend the Supabase SQL schema with task-related entities and generate migrations.
+- **Step 5:** Implement task CRUD APIs and shared DTOs.
+- **Step 6:** Introduce recurrence utilities and integrate them into task services.
+- **Steps 7-14:** Layer on progress updates, notifications, exports, and UI experiences specific to coaches and clients.
+
+By establishing a dedicated workspace now, subsequent steps can evolve without leaking domain-specific logic into unrelated parts of the application.

--- a/src/modules/tasks/api/index.ts
+++ b/src/modules/tasks/api/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Aggregates API-facing task module exports. Keeping re-exports
+ * alongside the API folder allows client hooks to import DTOs without
+ * depending on deeper service internals.
+ */
+export type { TaskDto, TaskInstanceDto, TaskListResponse } from '../types/task';
+export {
+  createTaskSchema,
+  updateTaskSchema,
+  taskListQuerySchema,
+} from '../types/task';

--- a/src/modules/tasks/components/index.ts
+++ b/src/modules/tasks/components/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview Aggregates React components that power the tasks experience.
+ * Placeholder exports ensure the module is recognized by TypeScript tooling
+ * before UI elements are implemented in later milestones.
+ */
+export {};

--- a/src/modules/tasks/hooks/index.ts
+++ b/src/modules/tasks/hooks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview Entry point for task-specific React hooks.
+ * Real implementations will be added when data fetching and state
+ * management utilities are introduced in subsequent steps.
+ */
+export {};

--- a/src/modules/tasks/services/index.ts
+++ b/src/modules/tasks/services/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview Re-export hub for task domain services.
+ * Exposing the service layer through a central module keeps consumer imports
+ * stable while additional services (progress, recurrence, notifications) are
+ * introduced in later steps of the implementation plan.
+ */
+export { TaskService, TaskServiceError } from './task-service';
+export type { TaskActor, TaskActorRole } from './task-service';
+export {
+  RecurrenceService,
+  RecurrenceServiceError,
+} from './recurrence-service';
+export { ProgressService, ProgressServiceError } from './progress-service';

--- a/src/modules/tasks/services/progress-service.ts
+++ b/src/modules/tasks/services/progress-service.ts
@@ -1,0 +1,335 @@
+/**
+ * @fileoverview Service encapsulating Supabase operations for recording task
+ * progress updates and attachment metadata. The service performs access
+ * control, input normalization, persistence, and serialization so API route
+ * handlers remain focused on transport concerns.
+ */
+
+import { createAdminClient } from '@/lib/supabase/server';
+import type { Database } from '@/types/supabase';
+
+import type { TaskActor } from './task-service';
+import type {
+  AttachmentMetadataInput,
+  CreateProgressUpdateInput,
+  ProgressUpdateDto,
+  TaskAttachmentDto,
+} from '../types/progress';
+import type { TaskStatus } from '../types/task';
+
+type SupabaseClient = ReturnType<typeof createAdminClient>;
+
+type TaskRow = Database['public']['Tables']['tasks']['Row'];
+type TaskInstanceRow = Database['public']['Tables']['task_instances']['Row'];
+type ProgressRow = Database['public']['Tables']['task_progress_updates']['Row'];
+type AttachmentRow = Database['public']['Tables']['task_attachments']['Row'];
+
+type TaskInstanceRecord = TaskInstanceRow & {
+  task: Pick<TaskRow, 'id' | 'coach_id' | 'client_id' | 'status'>;
+};
+
+const DEFAULT_VISIBILITY = true;
+const accessDenied = (message = 'Access denied') =>
+  new ProgressServiceError(message, 403, 'ACCESS_DENIED');
+const instanceNotFound = () =>
+  new ProgressServiceError(
+    'Task instance not found',
+    404,
+    'INSTANCE_NOT_FOUND'
+  );
+
+const sanitizeNote = (note?: string | null) => {
+  if (!note) {
+    return null;
+  }
+  const trimmed = note.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const toNumber = (value: number | string | null | undefined): number => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+};
+
+const resolveInstanceStatus = (
+  percentage: number,
+  currentStatus: TaskStatus
+): TaskStatus => {
+  if (percentage >= 100) {
+    return 'COMPLETED';
+  }
+  if (percentage <= 0) {
+    return 'PENDING';
+  }
+  if (currentStatus === 'OVERDUE') {
+    return 'OVERDUE';
+  }
+  return 'IN_PROGRESS';
+};
+
+const serializeAttachment = (attachment: AttachmentRow): TaskAttachmentDto => ({
+  id: attachment.id,
+  taskInstanceId: attachment.task_instance_id,
+  progressUpdateId: attachment.progress_update_id,
+  fileName: attachment.file_name,
+  fileSize: toNumber(attachment.file_size as unknown as number | string),
+  mimeType: attachment.mime_type ?? null,
+  fileUrl: attachment.file_url,
+  storagePath: attachment.file_url.startsWith('http')
+    ? null
+    : attachment.file_url,
+  uploadedById: attachment.uploaded_by_id,
+  createdAt: new Date(attachment.created_at).toISOString(),
+});
+
+export class ProgressServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: string = 'PROGRESS_SERVICE_ERROR'
+  ) {
+    super(message);
+    this.name = 'ProgressServiceError';
+  }
+}
+
+export class ProgressService {
+  private clientInstance: SupabaseClient | null = null;
+
+  constructor(
+    private readonly clientFactory: () => SupabaseClient = createAdminClient
+  ) {}
+
+  private getClient(): SupabaseClient {
+    if (!this.clientInstance) {
+      this.clientInstance = this.clientFactory();
+    }
+    return this.clientInstance;
+  }
+
+  public async createProgressUpdate(
+    actor: TaskActor,
+    {
+      taskId,
+      taskInstanceId,
+      input,
+    }: {
+      taskId: string;
+      taskInstanceId: string;
+      input: CreateProgressUpdateInput;
+    }
+  ): Promise<ProgressUpdateDto> {
+    const client = this.getClient();
+
+    const instance = await this.fetchInstance(taskId, taskInstanceId);
+
+    this.ensureActorHasAccess(actor, instance);
+
+    const percentage =
+      input.percentage !== undefined
+        ? input.percentage
+        : toNumber(instance.completion_percentage);
+    const note = sanitizeNote(input.note ?? null);
+    const isVisible = input.isVisibleToCoach ?? DEFAULT_VISIBILITY;
+
+    const { data: progressRow, error: progressError } = await client
+      .from('task_progress_updates')
+      .insert({
+        task_instance_id: instance.id,
+        author_id: actor.id,
+        percentage,
+        note,
+        is_visible_to_coach: isVisible,
+      })
+      .select('*')
+      .single();
+
+    if (progressError || !progressRow) {
+      throw new ProgressServiceError(
+        progressError?.message ?? 'Failed to record progress update',
+        500,
+        'PROGRESS_CREATE_FAILED'
+      );
+    }
+
+    const attachments = await this.persistAttachments(
+      instance,
+      progressRow,
+      actor.id,
+      input.attachments ?? []
+    );
+
+    const currentStatus = instance.task.status as TaskStatus;
+    const nextStatus = resolveInstanceStatus(percentage, currentStatus);
+    const completedAt =
+      nextStatus === 'COMPLETED' ? new Date().toISOString() : null;
+
+    const { error: instanceUpdateError } = await client
+      .from('task_instances')
+      .update({
+        completion_percentage: percentage,
+        status: nextStatus,
+        completed_at: completedAt,
+      })
+      .eq('id', instance.id);
+
+    if (instanceUpdateError) {
+      throw new ProgressServiceError(
+        instanceUpdateError.message,
+        500,
+        'INSTANCE_UPDATE_FAILED'
+      );
+    }
+
+    if ((instance.task.status as TaskStatus) !== nextStatus) {
+      const { error: taskUpdateError } = await client
+        .from('tasks')
+        .update({ status: nextStatus })
+        .eq('id', instance.task.id);
+
+      if (taskUpdateError) {
+        throw new ProgressServiceError(
+          taskUpdateError.message,
+          500,
+          'TASK_STATUS_UPDATE_FAILED'
+        );
+      }
+    }
+
+    return {
+      id: progressRow.id,
+      taskId: instance.task.id,
+      taskInstanceId: instance.id,
+      authorId: progressRow.author_id,
+      percentage: progressRow.percentage,
+      note: progressRow.note ?? null,
+      isVisibleToCoach: progressRow.is_visible_to_coach ?? DEFAULT_VISIBILITY,
+      createdAt: new Date(progressRow.created_at).toISOString(),
+      instanceStatus: nextStatus,
+      completionPercentage: percentage,
+      completedAt,
+      attachments,
+    };
+  }
+
+  private async fetchInstance(
+    taskId: string,
+    taskInstanceId: string
+  ): Promise<TaskInstanceRecord> {
+    const client = this.getClient();
+
+    const { data, error } = await client
+      .from('task_instances')
+      .select(
+        `
+        id,
+        task_id,
+        status,
+        completion_percentage,
+        scheduled_date,
+        due_date,
+        created_at,
+        updated_at,
+        task:tasks!inner(
+          id,
+          coach_id,
+          client_id,
+          status
+        )
+      `
+      )
+      .eq('id', taskInstanceId)
+      .eq('task_id', taskId)
+      .single();
+
+    if (error || !data) {
+      throw instanceNotFound();
+    }
+
+    const record = data as TaskInstanceRow & {
+      task:
+        | Pick<TaskRow, 'id' | 'coach_id' | 'client_id' | 'status'>
+        | (Pick<TaskRow, 'id' | 'coach_id' | 'client_id' | 'status'> | null)[]
+        | null;
+    };
+
+    const relatedTask = Array.isArray(record.task)
+      ? record.task[0]
+      : record.task;
+
+    if (!relatedTask) {
+      throw new ProgressServiceError(
+        'Parent task missing for requested instance',
+        404,
+        'TASK_NOT_FOUND'
+      );
+    }
+
+    return {
+      ...record,
+      task: relatedTask,
+    } as TaskInstanceRecord;
+  }
+
+  private ensureActorHasAccess(actor: TaskActor, instance: TaskInstanceRecord) {
+    if (actor.role === 'admin') {
+      return;
+    }
+
+    if (actor.role === 'coach' && instance.task.coach_id === actor.id) {
+      return;
+    }
+
+    if (actor.role === 'client' && instance.task.client_id === actor.id) {
+      return;
+    }
+
+    throw accessDenied();
+  }
+
+  private async persistAttachments(
+    instance: TaskInstanceRecord,
+    progress: ProgressRow,
+    actorId: string,
+    attachments: AttachmentMetadataInput[]
+  ): Promise<TaskAttachmentDto[]> {
+    if (attachments.length === 0) {
+      return [];
+    }
+
+    const client = this.getClient();
+
+    const payload = attachments.map(attachment => ({
+      task_instance_id: instance.id,
+      progress_update_id: progress.id,
+      file_url: attachment.fileUrl,
+      file_name: attachment.fileName,
+      file_size: attachment.fileSize,
+      mime_type: attachment.mimeType ?? null,
+      uploaded_by_id: actorId,
+    }));
+
+    const { data, error } = await client
+      .from('task_attachments')
+      .insert(payload)
+      .select('*');
+
+    if (error || !data) {
+      await client.from('task_progress_updates').delete().eq('id', progress.id);
+
+      throw new ProgressServiceError(
+        error?.message ?? 'Failed to store attachment metadata',
+        500,
+        'ATTACHMENT_CREATE_FAILED'
+      );
+    }
+
+    return data.map(row => serializeAttachment(row as AttachmentRow));
+  }
+}

--- a/src/modules/tasks/services/recurrence-service.ts
+++ b/src/modules/tasks/services/recurrence-service.ts
@@ -1,0 +1,412 @@
+/**
+ * @fileoverview Service responsible for normalizing recurrence rules and
+ * generating task-instance schedules. The implementation purposefully avoids
+ * heavy third-party dependencies so it can run in constrained environments
+ * (e.g., sandboxes without npm registry access) while still covering the
+ * recurrence scenarios required by the Action Items & Homework roadmap.
+ */
+
+import {
+  recurrenceRuleSchema,
+  type RecurrenceRuleInput,
+  type RecurrenceRulePersisted,
+  type RecurrencePlan,
+} from '../types/recurrence';
+
+/** Maximum number of future instances generated during planning. */
+const DEFAULT_INSTANCE_LIMIT = 10;
+
+type RecurrenceWeekday = NonNullable<RecurrenceRuleInput['byWeekday']>[number];
+
+const WEEKDAY_INDEX: Record<RecurrenceWeekday, number> = {
+  MO: 1,
+  TU: 2,
+  WE: 3,
+  TH: 4,
+  FR: 5,
+  SA: 6,
+  SU: 0,
+};
+
+const INDEX_WEEKDAY: Record<number, RecurrenceWeekday> = {
+  0: 'SU',
+  1: 'MO',
+  2: 'TU',
+  3: 'WE',
+  4: 'TH',
+  5: 'FR',
+  6: 'SA',
+};
+
+const cloneDate = (value: Date) => new Date(value.getTime());
+
+const startOfWeek = (date: Date, weekStart: RecurrenceWeekday): Date => {
+  const result = cloneDate(date);
+  const current = result.getUTCDay();
+  const target = WEEKDAY_INDEX[weekStart];
+  const diff = (current - target + 7) % 7 || 0;
+  result.setUTCDate(result.getUTCDate() - diff);
+  result.setUTCHours(0, 0, 0, 0);
+  return result;
+};
+
+const addDays = (date: Date, days: number): Date => {
+  const result = cloneDate(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+};
+
+const addMonths = (date: Date, months: number): Date => {
+  const result = cloneDate(date);
+  const day = result.getUTCDate();
+  result.setUTCDate(1);
+  result.setUTCMonth(result.getUTCMonth() + months);
+  const monthLength = new Date(
+    result.getUTCFullYear(),
+    result.getUTCMonth() + 1,
+    0
+  ).getUTCDate();
+  result.setUTCDate(Math.min(day, monthLength));
+  return result;
+};
+
+const addYears = (date: Date, years: number): Date => {
+  const result = cloneDate(date);
+  result.setUTCFullYear(result.getUTCFullYear() + years);
+  return result;
+};
+
+const sortAndDeduplicate = (dates: Date[]): Date[] => {
+  const seen = new Set<number>();
+  return dates
+    .sort((a, b) => a.getTime() - b.getTime())
+    .filter(date => {
+      const time = date.getTime();
+      if (seen.has(time)) {
+        return false;
+      }
+      seen.add(time);
+      return true;
+    });
+};
+
+/**
+ * Error thrown when recurrence parsing or schedule generation fails.
+ */
+export class RecurrenceServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RecurrenceServiceError';
+  }
+}
+
+/**
+ * Service that converts recurrence metadata into deterministic instance plans.
+ */
+export class RecurrenceService {
+  constructor(
+    private readonly instanceLimit: number = DEFAULT_INSTANCE_LIMIT
+  ) {}
+
+  /** Exposes the maximum number of generated instances for external callers. */
+  public get maxInstances(): number {
+    return this.instanceLimit;
+  }
+
+  /**
+   * Creates a schedule plan for task creation/update flows.
+   */
+  public planInstances({
+    dueDate,
+    recurrenceRule,
+    maxInstances,
+  }: {
+    dueDate: Date | null;
+    recurrenceRule?: unknown;
+    maxInstances?: number;
+  }): RecurrencePlan {
+    const limit = Math.min(
+      maxInstances ?? this.instanceLimit,
+      this.instanceLimit
+    );
+
+    if (!dueDate) {
+      if (recurrenceRule) {
+        throw new RecurrenceServiceError(
+          'A due date is required when specifying a recurrence rule.'
+        );
+      }
+
+      return { recurrenceRule: null, instances: [] };
+    }
+
+    const normalizedRule = this.normalizeRule(recurrenceRule);
+
+    if (!normalizedRule) {
+      return {
+        recurrenceRule: null,
+        instances: [
+          {
+            dueDate: cloneDate(dueDate),
+            scheduledDate: cloneDate(dueDate),
+          },
+        ],
+      };
+    }
+
+    const occurrences = this.generateOccurrences(
+      dueDate,
+      normalizedRule,
+      limit
+    );
+
+    return {
+      recurrenceRule: this.persistRule(normalizedRule, dueDate, occurrences),
+      instances: occurrences.map(date => ({
+        dueDate: cloneDate(date),
+        scheduledDate: cloneDate(date),
+      })),
+    };
+  }
+
+  /**
+   * Normalizes arbitrary recurrence payloads into the strict schema.
+   */
+  public normalizeRule(rule: unknown): RecurrenceRuleInput | null {
+    if (rule === null || rule === undefined) {
+      return null;
+    }
+
+    if (typeof rule === 'string') {
+      throw new RecurrenceServiceError(
+        'String-based recurrence rules are not supported in this environment.'
+      );
+    }
+
+    if (typeof rule !== 'object') {
+      throw new RecurrenceServiceError('Unsupported recurrence payload.');
+    }
+
+    return recurrenceRuleSchema.parse(
+      this.extractRuleObject(rule as Record<string, unknown>)
+    );
+  }
+
+  private extractRuleObject(raw: Record<string, unknown>): unknown {
+    if (raw.rule && typeof raw.rule === 'object') {
+      return raw.rule;
+    }
+
+    if (raw.options && typeof raw.options === 'object') {
+      return raw.options;
+    }
+
+    return raw;
+  }
+
+  private generateOccurrences(
+    startDate: Date,
+    rule: RecurrenceRuleInput,
+    limit: number
+  ): Date[] {
+    const occurrences: Date[] = [];
+    const until = rule.until ? new Date(rule.until) : null;
+    const targetCount = rule.count ? Math.min(rule.count, limit) : limit;
+
+    const pushIfValid = (candidate: Date) => {
+      // Guard against inserting dates that fall before the provided start date.
+      // This is especially important for weekly recurrences with multiple
+      // weekdays where the rule might otherwise re-introduce days earlier in
+      // the same week (e.g., starting on Wednesday with BYDAY=MO,WE).
+      if (candidate < startDate) {
+        return;
+      }
+
+      if (until && candidate > until) {
+        return;
+      }
+
+      occurrences.push(candidate);
+    };
+
+    switch (rule.frequency) {
+      case 'DAILY': {
+        let current = cloneDate(startDate);
+        while (occurrences.length < targetCount) {
+          pushIfValid(cloneDate(current));
+          current = addDays(current, rule.interval);
+          if (until && current > until && occurrences.length >= targetCount) {
+            break;
+          }
+        }
+        break;
+      }
+      case 'WEEKLY': {
+        const weekStart = rule.weekStart ?? 'MO';
+        const weekdays =
+          rule.byWeekday && rule.byWeekday.length > 0
+            ? (Array.from(new Set(rule.byWeekday)) as RecurrenceWeekday[])
+            : [INDEX_WEEKDAY[startDate.getUTCDay()] as RecurrenceWeekday];
+
+        const applyStartTime = (date: Date) => {
+          const withTime = cloneDate(date);
+          withTime.setUTCHours(
+            startDate.getUTCHours(),
+            startDate.getUTCMinutes(),
+            startDate.getUTCSeconds(),
+            startDate.getUTCMilliseconds()
+          );
+          return withTime;
+        };
+
+        pushIfValid(cloneDate(startDate));
+
+        const weekCursor = startOfWeek(startDate, weekStart);
+        let weeksGenerated = 0;
+
+        while (occurrences.length < targetCount) {
+          const candidateWeek =
+            weeksGenerated === 0
+              ? startOfWeek(startDate, weekStart)
+              : addDays(weekCursor, weeksGenerated * rule.interval * 7);
+
+          for (const weekday of weekdays) {
+            const dayIndex = WEEKDAY_INDEX[weekday];
+            const candidate = applyStartTime(
+              addDays(
+                candidateWeek,
+                (dayIndex - candidateWeek.getUTCDay() + 7) % 7
+              )
+            );
+            if (
+              weeksGenerated === 0 &&
+              candidate.getTime() === startDate.getTime()
+            ) {
+              continue;
+            }
+            if (occurrences.length >= targetCount) {
+              break;
+            }
+            pushIfValid(candidate);
+          }
+
+          weeksGenerated += 1;
+          if (until && addDays(candidateWeek, rule.interval * 7) > until) {
+            break;
+          }
+        }
+        break;
+      }
+      case 'MONTHLY': {
+        const monthDays =
+          rule.byMonthDay && rule.byMonthDay.length > 0
+            ? sortAndDeduplicate(
+                rule.byMonthDay.map(
+                  day =>
+                    new Date(
+                      Date.UTC(
+                        startDate.getUTCFullYear(),
+                        startDate.getUTCMonth(),
+                        day
+                      )
+                    )
+                )
+              ).map(date => date.getUTCDate())
+            : [startDate.getUTCDate()];
+
+        let cursor = cloneDate(startDate);
+        while (occurrences.length < targetCount) {
+          for (const day of monthDays) {
+            const candidate = new Date(
+              Date.UTC(
+                cursor.getUTCFullYear(),
+                cursor.getUTCMonth(),
+                day,
+                cursor.getUTCHours(),
+                cursor.getUTCMinutes(),
+                cursor.getUTCSeconds(),
+                cursor.getUTCMilliseconds()
+              )
+            );
+            if (candidate.getUTCMonth() !== cursor.getUTCMonth()) {
+              continue;
+            }
+            pushIfValid(candidate);
+            if (occurrences.length >= targetCount) {
+              break;
+            }
+          }
+          cursor = addMonths(cursor, rule.interval);
+          if (until && cursor > until) {
+            break;
+          }
+        }
+        break;
+      }
+      case 'YEARLY': {
+        let cursor = cloneDate(startDate);
+        while (occurrences.length < targetCount) {
+          pushIfValid(cloneDate(cursor));
+          cursor = addYears(cursor, rule.interval);
+          if (until && cursor > until) {
+            break;
+          }
+        }
+        break;
+      }
+      default: {
+        throw new RecurrenceServiceError('Unsupported recurrence frequency.');
+      }
+    }
+
+    return sortAndDeduplicate(occurrences).slice(0, targetCount);
+  }
+
+  private persistRule(
+    rule: RecurrenceRuleInput,
+    startDate: Date,
+    occurrences: Date[]
+  ): RecurrenceRulePersisted {
+    const firstOccurrence = occurrences[0] ?? startDate;
+    return {
+      ...rule,
+      startDate: firstOccurrence.toISOString(),
+      rrule: this.toRRuleLikeString(rule, firstOccurrence),
+    };
+  }
+
+  private toRRuleLikeString(
+    rule: RecurrenceRuleInput,
+    startDate: Date
+  ): string {
+    const components: string[] = [`FREQ=${rule.frequency}`];
+
+    if (rule.interval && rule.interval !== 1) {
+      components.push(`INTERVAL=${rule.interval}`);
+    }
+
+    if (rule.count) {
+      components.push(`COUNT=${rule.count}`);
+    }
+
+    if (rule.until) {
+      components.push(
+        `UNTIL=${rule.until.replace(/[-:]/g, '').replace('.000', '')}`
+      );
+    }
+
+    if (rule.byWeekday && rule.byWeekday.length > 0) {
+      components.push(`BYDAY=${rule.byWeekday.join(',')}`);
+    }
+
+    if (rule.byMonthDay && rule.byMonthDay.length > 0) {
+      components.push(`BYMONTHDAY=${rule.byMonthDay.join(',')}`);
+    }
+
+    components.push(
+      `DTSTART=${startDate.toISOString().replace(/[-:]/g, '').replace('.000', '')}`
+    );
+
+    return components.join(';');
+  }
+}

--- a/src/modules/tasks/services/task-service.ts
+++ b/src/modules/tasks/services/task-service.ts
@@ -1,0 +1,512 @@
+/**
+ * @fileoverview Service encapsulating Supabase-backed operations for the task
+ * domain. The service coordinates validation, access control, recurrence
+ * planning, and serialization so that API handlers can remain thin orchestration
+ * layers.
+ */
+import { createAdminClient } from '@/lib/supabase/server';
+import type { Database, Json } from '@/types/supabase';
+
+import {
+  RecurrenceService,
+  RecurrenceServiceError,
+} from './recurrence-service';
+import type { RecurrencePlan } from '../types/recurrence';
+import type {
+  CreateTaskInput,
+  TaskDto,
+  TaskInstanceDto,
+  TaskListQueryInput,
+  TaskListResponse,
+  TaskPriority,
+  TaskStatus,
+  UpdateTaskInput,
+} from '../types/task';
+
+/** Roles that interact with the task domain. */
+export type TaskActorRole = 'admin' | 'coach' | 'client';
+
+export interface TaskActor {
+  id: string;
+  role: TaskActorRole;
+}
+
+type SupabaseClient = ReturnType<typeof createAdminClient>;
+type TaskRow = Database['public']['Tables']['tasks']['Row'];
+type TaskCategoryRow = Database['public']['Tables']['task_categories']['Row'];
+type TaskInstanceRow = Database['public']['Tables']['task_instances']['Row'];
+
+type TaskRecord = TaskRow & {
+  category?: (TaskCategoryRow | null) & { color_hex?: string | null };
+  instances?: TaskInstanceRow[] | null;
+};
+
+const TASK_SELECT = `
+  *,
+  category:task_categories!tasks_category_id_fkey(
+    id,
+    label,
+    color_hex
+  ),
+  instances:task_instances(*)
+`;
+
+const DEFAULT_INSTANCE_LIMIT = 10;
+
+const accessDenied = (message = 'Access denied') =>
+  new TaskServiceError(message, 403, 'ACCESS_DENIED');
+const taskNotFound = () =>
+  new TaskServiceError('Task not found', 404, 'TASK_NOT_FOUND');
+
+const toISOStringOrNull = (value: string | null | undefined) =>
+  value ? new Date(value).toISOString() : null;
+
+const serializeInstance = (instance: TaskInstanceRow): TaskInstanceDto => ({
+  id: instance.id,
+  taskId: instance.task_id,
+  scheduledDate: toISOStringOrNull(instance.scheduled_date),
+  dueDate: new Date(instance.due_date).toISOString(),
+  status: instance.status,
+  completionPercentage: instance.completion_percentage,
+  completedAt: toISOStringOrNull(instance.completed_at),
+  createdAt: new Date(instance.created_at).toISOString(),
+  updatedAt: new Date(instance.updated_at).toISOString(),
+});
+
+const serializeTask = (task: TaskRecord): TaskDto => {
+  const instances = [...(task.instances ?? [])]
+    .map(serializeInstance)
+    .sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+
+  const category = task.category
+    ? {
+        id: task.category.id,
+        label: task.category.label,
+        colorHex: task.category.color_hex ?? '#1D7A85',
+      }
+    : null;
+
+  return {
+    id: task.id,
+    coachId: task.coach_id,
+    clientId: task.client_id,
+    category,
+    title: task.title,
+    description: task.description,
+    priority: task.priority,
+    visibilityToCoach: task.visibility_to_coach,
+    dueDate: toISOStringOrNull(task.due_date),
+    recurrenceRule: task.recurrence_rule ?? null,
+    archivedAt: toISOStringOrNull(task.archived_at),
+    createdAt: new Date(task.created_at).toISOString(),
+    updatedAt: new Date(task.updated_at).toISOString(),
+    instances,
+  };
+};
+
+const isCoachRole = (role: TaskActorRole) =>
+  role === 'coach' || role === 'admin';
+
+const ensureActorCanViewTask = (task: TaskRow, actor: TaskActor) => {
+  if (actor.role === 'admin') {
+    return;
+  }
+
+  if (actor.role === 'coach' && task.coach_id === actor.id) {
+    return;
+  }
+
+  if (actor.role === 'client' && task.client_id === actor.id) {
+    return;
+  }
+
+  throw accessDenied();
+};
+
+const resolveCoachId = (actor: TaskActor, payloadCoachId?: string): string => {
+  if (actor.role === 'coach') {
+    return actor.id;
+  }
+
+  if (actor.role === 'admin') {
+    if (!payloadCoachId) {
+      throw new TaskServiceError(
+        'coachId is required when creating tasks as an admin',
+        400,
+        'COACH_ID_REQUIRED'
+      );
+    }
+    return payloadCoachId;
+  }
+
+  throw accessDenied();
+};
+
+const planRecurrence = (
+  recurrenceService: RecurrenceService,
+  { dueDate, recurrenceRule }: { dueDate: Date | null; recurrenceRule: unknown }
+): RecurrencePlan => {
+  try {
+    return recurrenceService.planInstances({ dueDate, recurrenceRule });
+  } catch (error) {
+    if (error instanceof RecurrenceServiceError) {
+      throw new TaskServiceError(error.message, 400, 'RECURRENCE_INVALID');
+    }
+    throw error;
+  }
+};
+
+const toJsonOrNull = (value: RecurrencePlan['recurrenceRule']): Json | null =>
+  value ? (value as unknown as Json) : null;
+
+export class TaskServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: string = 'TASK_SERVICE_ERROR'
+  ) {
+    super(message);
+    this.name = 'TaskServiceError';
+  }
+}
+
+export class TaskService {
+  private clientInstance: SupabaseClient | null = null;
+
+  constructor(
+    private readonly clientFactory: () => SupabaseClient = createAdminClient,
+    private readonly recurrenceService: RecurrenceService = new RecurrenceService(
+      DEFAULT_INSTANCE_LIMIT
+    )
+  ) {}
+
+  private getClient(): SupabaseClient {
+    if (!this.clientInstance) {
+      this.clientInstance = this.clientFactory();
+    }
+
+    return this.clientInstance;
+  }
+
+  public async createTask(
+    actor: TaskActor,
+    input: CreateTaskInput
+  ): Promise<TaskDto> {
+    if (!isCoachRole(actor.role)) {
+      throw accessDenied();
+    }
+
+    const client = this.getClient();
+
+    const coachId = resolveCoachId(actor, input.coachId);
+    const dueDate = input.dueDate ? new Date(input.dueDate) : null;
+    if (!dueDate && input.recurrenceRule) {
+      throw new TaskServiceError(
+        'A due date is required when specifying a recurrence rule',
+        400,
+        'DUE_DATE_REQUIRED'
+      );
+    }
+
+    const plan = dueDate
+      ? planRecurrence(this.recurrenceService, {
+          dueDate,
+          recurrenceRule: input.recurrenceRule ?? null,
+        })
+      : { recurrenceRule: null, instances: [] };
+
+    const firstDueDate =
+      plan.instances[0]?.dueDate ?? (dueDate ? new Date(dueDate) : null);
+
+    const { data: insertedTask, error: insertError } = await client
+      .from('tasks')
+      .insert({
+        coach_id: coachId,
+        client_id: input.clientId,
+        category_id: input.categoryId ?? null,
+        title: input.title,
+        description: input.description ?? null,
+        priority: (input.priority ?? 'MEDIUM') as TaskPriority,
+        status: 'PENDING' satisfies TaskStatus,
+        visibility_to_coach: input.visibilityToCoach ?? true,
+        due_date: firstDueDate ? firstDueDate.toISOString() : null,
+        recurrence_rule: toJsonOrNull(plan.recurrenceRule),
+        archived_at: null,
+      })
+      .select(TASK_SELECT)
+      .single();
+
+    if (insertError || !insertedTask) {
+      throw new TaskServiceError(
+        insertError?.message ?? 'Failed to create task',
+        500,
+        'TASK_CREATE_FAILED'
+      );
+    }
+
+    if (plan.instances.length > 0) {
+      const { error: instanceError } = await client
+        .from('task_instances')
+        .insert(
+          plan.instances.map(instance => ({
+            task_id: insertedTask.id,
+            due_date: instance.dueDate.toISOString(),
+            scheduled_date: instance.scheduledDate.toISOString(),
+            status: 'PENDING' as TaskStatus,
+            completion_percentage: 0,
+          }))
+        );
+
+      if (instanceError) {
+        throw new TaskServiceError(
+          instanceError.message,
+          500,
+          'TASK_INSTANCE_CREATE_FAILED'
+        );
+      }
+    }
+
+    return this.getTaskById(insertedTask.id, actor);
+  }
+
+  public async listTasks(
+    actor: TaskActor,
+    filters: TaskListQueryInput
+  ): Promise<TaskListResponse> {
+    if (!isCoachRole(actor.role)) {
+      throw accessDenied();
+    }
+
+    const client = this.getClient();
+
+    const coachId = resolveCoachId(actor, filters.coachId);
+
+    const page = filters.page ?? 1;
+    const pageSize = filters.pageSize ?? 20;
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = client
+      .from('tasks')
+      .select(TASK_SELECT, { count: 'exact' })
+      .eq('coach_id', coachId);
+
+    if (filters.clientId) {
+      query = query.eq('client_id', filters.clientId);
+    }
+
+    if (filters.categoryId) {
+      query = query.eq('category_id', filters.categoryId);
+    }
+
+    if (filters.priority && filters.priority.length > 0) {
+      query = query.in('priority', filters.priority as TaskPriority[]);
+    }
+
+    if (filters.status && filters.status.length > 0) {
+      query = query.in('status', filters.status as TaskStatus[]);
+    }
+
+    if (!filters.includeArchived) {
+      query = query.is('archived_at', null);
+    }
+
+    if (filters.search) {
+      query = query.ilike('title', `%${filters.search}%`);
+    }
+
+    if (filters.dueDateFrom) {
+      query = query.gte('due_date', filters.dueDateFrom);
+    }
+
+    if (filters.dueDateTo) {
+      query = query.lte('due_date', filters.dueDateTo);
+    }
+
+    const ascending = filters.sortOrder !== 'desc';
+
+    if (filters.sort === 'createdAt') {
+      query = query.order('created_at', { ascending });
+    } else {
+      query = query
+        .order('due_date', { ascending, nullsFirst: true })
+        .order('created_at', { ascending: false });
+    }
+
+    const { data, error, count } = await query.range(from, to);
+
+    if (error) {
+      throw new TaskServiceError(error.message, 500, 'TASK_LIST_FAILED');
+    }
+
+    const rows = (data ?? []) as TaskRecord[];
+    const tasks = rows.map(serializeTask);
+    const total = count ?? tasks.length;
+
+    return {
+      data: tasks,
+      pagination: {
+        page,
+        pageSize,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / pageSize)),
+      },
+    };
+  }
+
+  public async getTaskById(taskId: string, actor: TaskActor): Promise<TaskDto> {
+    const task = await this.fetchTaskRecord(taskId);
+    ensureActorCanViewTask(task, actor);
+    return serializeTask(task as TaskRecord);
+  }
+
+  public async updateTask(
+    taskId: string,
+    actor: TaskActor,
+    payload: UpdateTaskInput
+  ): Promise<TaskDto> {
+    if (!isCoachRole(actor.role)) {
+      throw accessDenied();
+    }
+
+    const client = this.getClient();
+
+    const task = await this.fetchTaskRecord(taskId);
+
+    if (actor.role === 'coach' && task.coach_id !== actor.id) {
+      throw accessDenied();
+    }
+
+    const updates: Database['public']['Tables']['tasks']['Update'] = {};
+
+    if (payload.title !== undefined) {
+      updates.title = payload.title;
+    }
+
+    if (payload.description !== undefined) {
+      updates.description = payload.description ?? null;
+    }
+
+    if (payload.categoryId !== undefined) {
+      updates.category_id = payload.categoryId ?? null;
+    }
+
+    if (payload.priority !== undefined) {
+      updates.priority = payload.priority as TaskPriority;
+    }
+
+    if (payload.visibilityToCoach !== undefined) {
+      updates.visibility_to_coach = payload.visibilityToCoach;
+    }
+
+    if (payload.archivedAt !== undefined) {
+      updates.archived_at = payload.archivedAt ?? null;
+    }
+
+    if (payload.status !== undefined) {
+      updates.status = payload.status as TaskStatus;
+    }
+
+    const shouldRebuildInstances =
+      payload.dueDate !== undefined || payload.recurrenceRule !== undefined;
+
+    if (shouldRebuildInstances) {
+      const effectiveDueDate = payload.dueDate
+        ? new Date(payload.dueDate)
+        : task.due_date
+          ? new Date(task.due_date)
+          : null;
+
+      const plan = effectiveDueDate
+        ? planRecurrence(this.recurrenceService, {
+            dueDate: effectiveDueDate,
+            recurrenceRule:
+              payload.recurrenceRule !== undefined
+                ? payload.recurrenceRule
+                : (task.recurrence_rule ?? null),
+          })
+        : { recurrenceRule: null, instances: [] };
+
+      const firstDueDate =
+        plan.instances[0]?.dueDate ??
+        (effectiveDueDate ? new Date(effectiveDueDate) : null);
+
+      updates.due_date = firstDueDate ? firstDueDate.toISOString() : null;
+      updates.recurrence_rule = toJsonOrNull(plan.recurrenceRule);
+
+      const { error: deleteError } = await client
+        .from('task_instances')
+        .delete()
+        .eq('task_id', taskId);
+
+      if (deleteError) {
+        throw new TaskServiceError(
+          deleteError.message,
+          500,
+          'TASK_INSTANCE_DELETE_FAILED'
+        );
+      }
+
+      if (plan.instances.length > 0) {
+        const { error: insertError } = await client
+          .from('task_instances')
+          .insert(
+            plan.instances.map(instance => ({
+              task_id: taskId,
+              due_date: instance.dueDate.toISOString(),
+              scheduled_date: instance.scheduledDate.toISOString(),
+              status: 'PENDING' as TaskStatus,
+              completion_percentage: 0,
+            }))
+          );
+
+        if (insertError) {
+          throw new TaskServiceError(
+            insertError.message,
+            500,
+            'TASK_INSTANCE_CREATE_FAILED'
+          );
+        }
+      }
+    } else if (payload.dueDate !== undefined) {
+      updates.due_date = payload.dueDate ?? null;
+    }
+
+    if (payload.recurrenceRule === null && !shouldRebuildInstances) {
+      updates.recurrence_rule = null;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      const { error: updateError } = await client
+        .from('tasks')
+        .update(updates)
+        .eq('id', taskId);
+
+      if (updateError) {
+        throw new TaskServiceError(
+          updateError.message,
+          500,
+          'TASK_UPDATE_FAILED'
+        );
+      }
+    }
+
+    return this.getTaskById(taskId, actor);
+  }
+
+  private async fetchTaskRecord(taskId: string): Promise<TaskRecord> {
+    const client = this.getClient();
+
+    const { data, error } = await client
+      .from('tasks')
+      .select(TASK_SELECT)
+      .eq('id', taskId)
+      .single();
+
+    if (error || !data) {
+      throw taskNotFound();
+    }
+
+    return data as TaskRecord;
+  }
+}

--- a/src/modules/tasks/types/index.ts
+++ b/src/modules/tasks/types/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview Barrel file re-exporting task module types so that API routes
+ * and UI code can import strongly-typed contracts from a single location.
+ */
+export * from './task';
+export * from './recurrence';
+export * from './progress';

--- a/src/modules/tasks/types/progress.ts
+++ b/src/modules/tasks/types/progress.ts
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Shared schemas and DTOs for task progress updates and
+ * attachment metadata. These types ensure API handlers, services, and client
+ * consumers exchange consistent payloads when clients log their homework
+ * progress or upload supporting evidence.
+ */
+import { z } from 'zod';
+
+import { config } from '@/lib/config';
+
+import type { TaskStatus } from './task';
+const MAX_NOTE_LENGTH = 2000;
+const MAX_ATTACHMENTS = 5;
+const MAX_FILE_SIZE = config.file.DOCUMENT_MAX_SIZE;
+
+/**
+ * Schema describing metadata for attachments associated with a progress
+ * update. The client uploads files through a signed URL workflow and then
+ * persists the resulting paths and details with the progress entry.
+ */
+export const attachmentMetadataSchema = z.object({
+  fileName: z
+    .string()
+    .min(1, 'File name is required')
+    .max(255, 'File name must be 255 characters or fewer'),
+  fileSize: z
+    .number({ invalid_type_error: 'File size must be a number' })
+    .int('File size must be an integer')
+    .min(0, 'File size must be greater than or equal to zero')
+    .max(MAX_FILE_SIZE, `File size must be ${MAX_FILE_SIZE} bytes or smaller`),
+  mimeType: z
+    .string()
+    .min(1, 'MIME type is required')
+    .max(120, 'MIME type must be 120 characters or fewer')
+    .optional(),
+  fileUrl: z
+    .string()
+    .min(1, 'File URL is required')
+    .max(1024, 'File URL must be 1024 characters or fewer'),
+  storagePath: z
+    .string()
+    .min(1, 'Storage path is required')
+    .max(1024, 'Storage path must be 1024 characters or fewer')
+    .optional(),
+});
+
+/**
+ * Schema describing the payload accepted by the progress update endpoint.
+ * At least one meaningful field (percentage, note, or attachment) must be
+ * provided to avoid inserting empty updates.
+ */
+export const createProgressUpdateSchema = z
+  .object({
+    percentage: z
+      .number({ invalid_type_error: 'Percentage must be a number' })
+      .int('Percentage must be an integer')
+      .min(0, 'Percentage must be between 0 and 100')
+      .max(100, 'Percentage must be between 0 and 100')
+      .optional(),
+    note: z
+      .string()
+      .max(
+        MAX_NOTE_LENGTH,
+        `Note must be ${MAX_NOTE_LENGTH} characters or fewer`
+      )
+      .transform(value => value.trim())
+      .optional(),
+    isVisibleToCoach: z.boolean().optional(),
+    attachments: z
+      .array(attachmentMetadataSchema)
+      .max(
+        MAX_ATTACHMENTS,
+        `You can attach up to ${MAX_ATTACHMENTS} files per update`
+      )
+      .optional(),
+  })
+  .refine(
+    payload => {
+      const hasPercentage = payload.percentage !== undefined;
+      const hasNote = Boolean(payload.note && payload.note.length > 0);
+      const hasAttachments = Boolean(payload.attachments?.length);
+      return hasPercentage || hasNote || hasAttachments;
+    },
+    {
+      message:
+        'Provide a percentage, note, or at least one attachment when submitting progress',
+    }
+  );
+
+export type CreateProgressUpdateInput = z.infer<
+  typeof createProgressUpdateSchema
+>;
+export type AttachmentMetadataInput = z.infer<typeof attachmentMetadataSchema>;
+
+/**
+ * Attachment metadata returned to API consumers after persistence.
+ */
+export interface TaskAttachmentDto {
+  id: string;
+  taskInstanceId: string | null;
+  progressUpdateId: string | null;
+  fileName: string;
+  fileSize: number;
+  mimeType: string | null;
+  fileUrl: string;
+  storagePath?: string | null;
+  uploadedById: string | null;
+  createdAt: string;
+}
+
+/**
+ * Progress update metadata returned to API consumers.
+ */
+export interface ProgressUpdateDto {
+  id: string;
+  taskId: string;
+  taskInstanceId: string;
+  authorId: string;
+  percentage: number;
+  note: string | null;
+  isVisibleToCoach: boolean;
+  createdAt: string;
+  instanceStatus: TaskStatus;
+  completionPercentage: number;
+  completedAt: string | null;
+  attachments: TaskAttachmentDto[];
+}
+
+/**
+ * Helper for referencing path parameters when constructing service calls.
+ */
+export interface ProgressRouteParams {
+  taskId: string;
+  instanceId: string;
+}

--- a/src/modules/tasks/types/recurrence.ts
+++ b/src/modules/tasks/types/recurrence.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Shared recurrence rule schemas and types for the task domain.
+ * These definitions provide a normalized shape for recurrence configuration so
+ * services and API layers can safely parse and persist scheduling metadata.
+ */
+import { z } from 'zod';
+
+/** Supported recurrence frequencies, mirroring the RFC 5545 spec. */
+export const recurrenceFrequencySchema = z.enum([
+  'DAILY',
+  'WEEKLY',
+  'MONTHLY',
+  'YEARLY',
+]);
+
+/** Supported weekday identifiers (RFC 5545 two-character codes). */
+export const recurrenceWeekdaySchema = z.enum([
+  'MO',
+  'TU',
+  'WE',
+  'TH',
+  'FR',
+  'SA',
+  'SU',
+]);
+
+/** ISO string schema reused for until/start values. */
+const isoDateSchema = z
+  .string()
+  .datetime({ message: 'Value must be an ISO-8601 date string' });
+
+/**
+ * Schema describing the recurrence rule payload accepted by the API layer.
+ * The structure intentionally aligns with a subset of the RFC 5545 options so
+ * that conversion to recurrence schedules remains deterministic and auditable.
+ */
+export const recurrenceRuleSchema = z
+  .object({
+    frequency: recurrenceFrequencySchema,
+    interval: z.number().int().positive().max(366).default(1),
+    count: z.number().int().positive().max(366).optional(),
+    until: isoDateSchema.optional(),
+    byWeekday: z.array(recurrenceWeekdaySchema).min(1).optional(),
+    byMonthDay: z.array(z.number().int().min(1).max(31)).min(1).optional(),
+    bySetPosition: z.array(z.number().int().min(-53).max(53)).min(1).optional(),
+    weekStart: recurrenceWeekdaySchema.optional(),
+    timezone: z.string().min(1).optional(),
+  })
+  .strict();
+
+/**
+ * Type describing the normalized recurrence rule accepted by services.
+ */
+export type RecurrenceRuleInput = z.infer<typeof recurrenceRuleSchema>;
+
+/**
+ * Type describing the recurrence rule persisted on the Task model.
+ */
+export interface RecurrenceRulePersisted extends RecurrenceRuleInput {
+  /** ISO string capturing the seed date used when generating occurrences. */
+  startDate: string;
+  /** Stringified RRULE representation for interoperability/debugging. */
+  rrule: string;
+}
+
+/**
+ * Simple schedule entry describing a generated instance.
+ */
+export interface RecurrenceScheduleEntry {
+  dueDate: Date;
+  scheduledDate: Date;
+}
+
+/**
+ * Output describing recurrence planning for creation/update flows.
+ */
+export interface RecurrencePlan {
+  recurrenceRule: RecurrenceRulePersisted | null;
+  instances: RecurrenceScheduleEntry[];
+}

--- a/src/modules/tasks/types/task.ts
+++ b/src/modules/tasks/types/task.ts
@@ -1,0 +1,171 @@
+/**
+ * @fileoverview Zod schemas and DTO definitions for the task domain API.
+ * These types provide a shared contract between route handlers, services,
+ * and client-side consumers when creating, updating, and retrieving tasks.
+ */
+import { z } from 'zod';
+
+import { recurrenceRuleSchema } from './recurrence';
+
+const taskPriorityTuple = ['LOW', 'MEDIUM', 'HIGH'] as const;
+type TaskPriorityTuple = typeof taskPriorityTuple;
+export type TaskPriority = TaskPriorityTuple[number];
+export const taskPriorityValues: readonly TaskPriority[] = [
+  ...taskPriorityTuple,
+];
+
+const taskStatusTuple = [
+  'PENDING',
+  'IN_PROGRESS',
+  'COMPLETED',
+  'OVERDUE',
+] as const;
+type TaskStatusTuple = typeof taskStatusTuple;
+export type TaskStatus = TaskStatusTuple[number];
+export const taskStatusValues: readonly TaskStatus[] = [...taskStatusTuple];
+
+/**
+ * Utility schema that converts ISO-8601 strings into native JavaScript Date
+ * instances. The API accepts ISO strings and service layers operate on Date
+ * objects so downstream database helpers can work with native types.
+ */
+const isoDateStringSchema = z
+  .string()
+  .datetime({ message: 'Value must be an ISO-8601 date string' });
+
+const uuidSchema = z.string().uuid({ message: 'Value must be a valid UUID' });
+
+/**
+ * Schema describing the body accepted by the collection POST handler.
+ */
+const taskPrioritySchema = z.enum(taskPriorityTuple);
+
+const taskStatusSchema = z.enum(taskStatusTuple);
+
+export const createTaskSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title is required')
+    .max(200, 'Title must be 200 characters or fewer'),
+  description: z
+    .string()
+    .max(2000, 'Description must be 2000 characters or fewer')
+    .optional(),
+  clientId: uuidSchema,
+  coachId: uuidSchema.optional(),
+  categoryId: uuidSchema.optional(),
+  priority: taskPrioritySchema.default('MEDIUM').optional(),
+  visibilityToCoach: z.boolean().optional(),
+  dueDate: isoDateStringSchema.optional(),
+  recurrenceRule: recurrenceRuleSchema.nullable().optional(),
+});
+
+/**
+ * Schema describing the payload accepted by the item PATCH handler.
+ */
+export const updateTaskSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, 'Title is required')
+      .max(200, 'Title must be 200 characters or fewer')
+      .optional(),
+    description: z
+      .string()
+      .max(2000, 'Description must be 2000 characters or fewer')
+      .nullable()
+      .optional(),
+    categoryId: uuidSchema.nullish(),
+    priority: taskPrioritySchema.optional(),
+    visibilityToCoach: z.boolean().optional(),
+    dueDate: isoDateStringSchema.optional(),
+    archivedAt: isoDateStringSchema.nullable().optional(),
+    status: taskStatusSchema.optional(),
+    recurrenceRule: recurrenceRuleSchema.nullable().optional(),
+  })
+  .refine(payload => payload !== null && Object.keys(payload).length > 0, {
+    message: 'At least one property must be provided for an update',
+  });
+
+const booleanFromQuery = z
+  .union([z.literal('true'), z.literal('false')])
+  .optional()
+  .transform(value => (value === undefined ? undefined : value === 'true'));
+
+/**
+ * Schema describing the supported query parameters for list retrieval.
+ */
+export const taskListQuerySchema = z.object({
+  coachId: uuidSchema.optional(),
+  clientId: uuidSchema.optional(),
+  categoryId: uuidSchema.optional(),
+  status: z.array(taskStatusSchema).optional(),
+  priority: z.array(taskPrioritySchema).optional(),
+  includeArchived: booleanFromQuery,
+  search: z
+    .string()
+    .max(120, 'Search must be 120 characters or fewer')
+    .optional(),
+  dueDateFrom: isoDateStringSchema.optional(),
+  dueDateTo: isoDateStringSchema.optional(),
+  sort: z.enum(['dueDate', 'createdAt']).default('dueDate'),
+  sortOrder: z.enum(['asc', 'desc']).default('asc'),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>;
+export type UpdateTaskInput = z.infer<typeof updateTaskSchema>;
+export type TaskListQueryInput = z.infer<typeof taskListQuerySchema>;
+
+/**
+ * DTO describing a task instance returned to API consumers.
+ */
+export interface TaskInstanceDto {
+  id: string;
+  taskId: string;
+  scheduledDate: string | null;
+  dueDate: string;
+  status: TaskStatus;
+  completionPercentage: number;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * DTO describing task metadata returned to API consumers.
+ */
+export interface TaskDto {
+  id: string;
+  coachId: string;
+  clientId: string;
+  category?: {
+    id: string;
+    label: string;
+    colorHex: string;
+  } | null;
+  title: string;
+  description?: string | null;
+  priority: TaskPriority;
+  visibilityToCoach: boolean;
+  dueDate?: string | null;
+  recurrenceRule?: unknown;
+  archivedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  instances: TaskInstanceDto[];
+}
+
+/**
+ * Response envelope used by the list endpoint.
+ */
+export interface TaskListResponse {
+  data: TaskDto[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -4,7407 +4,7769 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          variables?: Json
-          operationName?: string
-          query?: string
-          extensions?: Json
-        }
-        Returns: Json
-      }
-    }
+          variables?: Json;
+          operationName?: string;
+          query?: string;
+          extensions?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       audit_logs: {
         Row: {
-          action: string
-          created_at: string | null
-          details: Json | null
-          id: string
-          ip_address: unknown | null
-          resource_id: string | null
-          resource_type: string | null
-          user_agent: string | null
-          user_id: string | null
-        }
+          action: string;
+          created_at: string | null;
+          details: Json | null;
+          id: string;
+          ip_address: unknown | null;
+          resource_id: string | null;
+          resource_type: string | null;
+          user_agent: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          action: string
-          created_at?: string | null
-          details?: Json | null
-          id?: string
-          ip_address?: unknown | null
-          resource_id?: string | null
-          resource_type?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          action: string;
+          created_at?: string | null;
+          details?: Json | null;
+          id?: string;
+          ip_address?: unknown | null;
+          resource_id?: string | null;
+          resource_type?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          action?: string
-          created_at?: string | null
-          details?: Json | null
-          id?: string
-          ip_address?: unknown | null
-          resource_id?: string | null
-          resource_type?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          action?: string;
+          created_at?: string | null;
+          details?: Json | null;
+          id?: string;
+          ip_address?: unknown | null;
+          resource_id?: string | null;
+          resource_type?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "audit_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'audit_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "audit_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'audit_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "audit_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'audit_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "audit_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'audit_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "audit_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'audit_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "audit_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'audit_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       blocked_ips: {
         Row: {
-          blocked_at: string | null
-          blocked_by: string | null
-          blocked_reason: string
-          expires_at: string | null
-          id: string
-          ip_address: unknown
-          is_active: boolean | null
-          unblock_reason: string | null
-          unblocked_at: string | null
-          unblocked_by: string | null
-        }
+          blocked_at: string | null;
+          blocked_by: string | null;
+          blocked_reason: string;
+          expires_at: string | null;
+          id: string;
+          ip_address: unknown;
+          is_active: boolean | null;
+          unblock_reason: string | null;
+          unblocked_at: string | null;
+          unblocked_by: string | null;
+        };
         Insert: {
-          blocked_at?: string | null
-          blocked_by?: string | null
-          blocked_reason: string
-          expires_at?: string | null
-          id?: string
-          ip_address: unknown
-          is_active?: boolean | null
-          unblock_reason?: string | null
-          unblocked_at?: string | null
-          unblocked_by?: string | null
-        }
+          blocked_at?: string | null;
+          blocked_by?: string | null;
+          blocked_reason: string;
+          expires_at?: string | null;
+          id?: string;
+          ip_address: unknown;
+          is_active?: boolean | null;
+          unblock_reason?: string | null;
+          unblocked_at?: string | null;
+          unblocked_by?: string | null;
+        };
         Update: {
-          blocked_at?: string | null
-          blocked_by?: string | null
-          blocked_reason?: string
-          expires_at?: string | null
-          id?: string
-          ip_address?: unknown
-          is_active?: boolean | null
-          unblock_reason?: string | null
-          unblocked_at?: string | null
-          unblocked_by?: string | null
-        }
+          blocked_at?: string | null;
+          blocked_by?: string | null;
+          blocked_reason?: string;
+          expires_at?: string | null;
+          id?: string;
+          ip_address?: unknown;
+          is_active?: boolean | null;
+          unblock_reason?: string | null;
+          unblocked_at?: string | null;
+          unblocked_by?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "blocked_ips_blocked_by_fkey"
-            columns: ["blocked_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'blocked_ips_blocked_by_fkey';
+            columns: ['blocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "blocked_ips_blocked_by_fkey"
-            columns: ["blocked_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'blocked_ips_blocked_by_fkey';
+            columns: ['blocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "blocked_ips_blocked_by_fkey"
-            columns: ["blocked_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'blocked_ips_blocked_by_fkey';
+            columns: ['blocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "blocked_ips_blocked_by_fkey"
-            columns: ["blocked_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'blocked_ips_blocked_by_fkey';
+            columns: ['blocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "blocked_ips_blocked_by_fkey"
-            columns: ["blocked_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'blocked_ips_blocked_by_fkey';
+            columns: ['blocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "blocked_ips_blocked_by_fkey"
-            columns: ["blocked_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'blocked_ips_blocked_by_fkey';
+            columns: ['blocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "blocked_ips_unblocked_by_fkey"
-            columns: ["unblocked_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'blocked_ips_unblocked_by_fkey';
+            columns: ['unblocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "blocked_ips_unblocked_by_fkey"
-            columns: ["unblocked_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'blocked_ips_unblocked_by_fkey';
+            columns: ['unblocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "blocked_ips_unblocked_by_fkey"
-            columns: ["unblocked_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'blocked_ips_unblocked_by_fkey';
+            columns: ['unblocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "blocked_ips_unblocked_by_fkey"
-            columns: ["unblocked_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'blocked_ips_unblocked_by_fkey';
+            columns: ['unblocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "blocked_ips_unblocked_by_fkey"
-            columns: ["unblocked_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'blocked_ips_unblocked_by_fkey';
+            columns: ['unblocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "blocked_ips_unblocked_by_fkey"
-            columns: ["unblocked_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'blocked_ips_unblocked_by_fkey';
+            columns: ['unblocked_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       client_goals: {
         Row: {
-          category: string | null
-          client_id: string
-          coach_id: string
-          completed_at: string | null
-          created_at: string | null
-          description: string | null
-          id: string
-          priority: string
-          progress_percentage: number | null
-          status: string
-          target_date: string | null
-          title: string
-          updated_at: string | null
-        }
+          category: string | null;
+          client_id: string;
+          coach_id: string;
+          completed_at: string | null;
+          created_at: string | null;
+          description: string | null;
+          id: string;
+          priority: string;
+          progress_percentage: number | null;
+          status: string;
+          target_date: string | null;
+          title: string;
+          updated_at: string | null;
+        };
         Insert: {
-          category?: string | null
-          client_id: string
-          coach_id: string
-          completed_at?: string | null
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          priority?: string
-          progress_percentage?: number | null
-          status?: string
-          target_date?: string | null
-          title: string
-          updated_at?: string | null
-        }
+          category?: string | null;
+          client_id: string;
+          coach_id: string;
+          completed_at?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          priority?: string;
+          progress_percentage?: number | null;
+          status?: string;
+          target_date?: string | null;
+          title: string;
+          updated_at?: string | null;
+        };
         Update: {
-          category?: string | null
-          client_id?: string
-          coach_id?: string
-          completed_at?: string | null
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          priority?: string
-          progress_percentage?: number | null
-          status?: string
-          target_date?: string | null
-          title?: string
-          updated_at?: string | null
-        }
+          category?: string | null;
+          client_id?: string;
+          coach_id?: string;
+          completed_at?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          priority?: string;
+          progress_percentage?: number | null;
+          status?: string;
+          target_date?: string | null;
+          title?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "client_goals_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'client_goals_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "client_goals_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'client_goals_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "client_goals_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'client_goals_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "client_goals_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'client_goals_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "client_goals_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'client_goals_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "client_goals_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'client_goals_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "client_goals_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'client_goals_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "client_goals_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'client_goals_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "client_goals_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'client_goals_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "client_goals_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'client_goals_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "client_goals_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'client_goals_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "client_goals_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'client_goals_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       coach_availability: {
         Row: {
-          buffer_after_minutes: number | null
-          buffer_before_minutes: number | null
-          coach_id: string
-          created_at: string | null
-          day_of_week: number
-          end_time: string
-          id: string
-          is_available: boolean
-          max_bookings_per_slot: number | null
-          start_time: string
-          timezone: string
-          updated_at: string | null
-        }
+          buffer_after_minutes: number | null;
+          buffer_before_minutes: number | null;
+          coach_id: string;
+          created_at: string | null;
+          day_of_week: number;
+          end_time: string;
+          id: string;
+          is_available: boolean;
+          max_bookings_per_slot: number | null;
+          start_time: string;
+          timezone: string;
+          updated_at: string | null;
+        };
         Insert: {
-          buffer_after_minutes?: number | null
-          buffer_before_minutes?: number | null
-          coach_id: string
-          created_at?: string | null
-          day_of_week: number
-          end_time: string
-          id?: string
-          is_available?: boolean
-          max_bookings_per_slot?: number | null
-          start_time: string
-          timezone?: string
-          updated_at?: string | null
-        }
+          buffer_after_minutes?: number | null;
+          buffer_before_minutes?: number | null;
+          coach_id: string;
+          created_at?: string | null;
+          day_of_week: number;
+          end_time: string;
+          id?: string;
+          is_available?: boolean;
+          max_bookings_per_slot?: number | null;
+          start_time: string;
+          timezone?: string;
+          updated_at?: string | null;
+        };
         Update: {
-          buffer_after_minutes?: number | null
-          buffer_before_minutes?: number | null
-          coach_id?: string
-          created_at?: string | null
-          day_of_week?: number
-          end_time?: string
-          id?: string
-          is_available?: boolean
-          max_bookings_per_slot?: number | null
-          start_time?: string
-          timezone?: string
-          updated_at?: string | null
-        }
+          buffer_after_minutes?: number | null;
+          buffer_before_minutes?: number | null;
+          coach_id?: string;
+          created_at?: string | null;
+          day_of_week?: number;
+          end_time?: string;
+          id?: string;
+          is_available?: boolean;
+          max_bookings_per_slot?: number | null;
+          start_time?: string;
+          timezone?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       coach_notes: {
         Row: {
-          client_id: string
-          coach_id: string
-          content: string
-          created_at: string | null
-          id: string
-          privacy_level: Database["public"]["Enums"]["privacy_level"]
-          session_id: string | null
-          tags: string[] | null
-          title: string
-          updated_at: string | null
-        }
+          client_id: string;
+          coach_id: string;
+          content: string;
+          created_at: string | null;
+          id: string;
+          privacy_level: Database['public']['Enums']['privacy_level'];
+          session_id: string | null;
+          tags: string[] | null;
+          title: string;
+          updated_at: string | null;
+        };
         Insert: {
-          client_id: string
-          coach_id: string
-          content: string
-          created_at?: string | null
-          id?: string
-          privacy_level?: Database["public"]["Enums"]["privacy_level"]
-          session_id?: string | null
-          tags?: string[] | null
-          title: string
-          updated_at?: string | null
-        }
+          client_id: string;
+          coach_id: string;
+          content: string;
+          created_at?: string | null;
+          id?: string;
+          privacy_level?: Database['public']['Enums']['privacy_level'];
+          session_id?: string | null;
+          tags?: string[] | null;
+          title: string;
+          updated_at?: string | null;
+        };
         Update: {
-          client_id?: string
-          coach_id?: string
-          content?: string
-          created_at?: string | null
-          id?: string
-          privacy_level?: Database["public"]["Enums"]["privacy_level"]
-          session_id?: string | null
-          tags?: string[] | null
-          title?: string
-          updated_at?: string | null
-        }
+          client_id?: string;
+          coach_id?: string;
+          content?: string;
+          created_at?: string | null;
+          id?: string;
+          privacy_level?: Database['public']['Enums']['privacy_level'];
+          session_id?: string | null;
+          tags?: string[] | null;
+          title?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "coach_notes_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_notes_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_notes_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_notes_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_notes_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_notes_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_notes_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_notes_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_notes_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'coach_notes_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "coach_notes_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_notes_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "coach_notes_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_notes_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_notes_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_notes_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_notes_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_notes_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_notes_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_notes_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_notes_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'coach_notes_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "coach_notes_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_notes_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "coach_notes_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_notes_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "coach_notes_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_notes_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       coach_profiles: {
         Row: {
-          bio: string | null
-          certifications: Json | null
-          coach_id: string
-          created_at: string | null
-          currency: string
-          experience_years: number | null
-          id: string
-          languages: string[] | null
-          session_rate: number
-          specializations: string[] | null
-          timezone: string | null
-          updated_at: string | null
-        }
+          bio: string | null;
+          certifications: Json | null;
+          coach_id: string;
+          created_at: string | null;
+          currency: string;
+          experience_years: number | null;
+          id: string;
+          languages: string[] | null;
+          session_rate: number;
+          specializations: string[] | null;
+          timezone: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          bio?: string | null
-          certifications?: Json | null
-          coach_id: string
-          created_at?: string | null
-          currency?: string
-          experience_years?: number | null
-          id?: string
-          languages?: string[] | null
-          session_rate?: number
-          specializations?: string[] | null
-          timezone?: string | null
-          updated_at?: string | null
-        }
+          bio?: string | null;
+          certifications?: Json | null;
+          coach_id: string;
+          created_at?: string | null;
+          currency?: string;
+          experience_years?: number | null;
+          id?: string;
+          languages?: string[] | null;
+          session_rate?: number;
+          specializations?: string[] | null;
+          timezone?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          bio?: string | null
-          certifications?: Json | null
-          coach_id?: string
-          created_at?: string | null
-          currency?: string
-          experience_years?: number | null
-          id?: string
-          languages?: string[] | null
-          session_rate?: number
-          specializations?: string[] | null
-          timezone?: string | null
-          updated_at?: string | null
-        }
+          bio?: string | null;
+          certifications?: Json | null;
+          coach_id?: string;
+          created_at?: string | null;
+          currency?: string;
+          experience_years?: number | null;
+          id?: string;
+          languages?: string[] | null;
+          session_rate?: number;
+          specializations?: string[] | null;
+          timezone?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "coach_profiles_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_profiles_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_profiles_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_profiles_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_profiles_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: true
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_profiles_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_profiles_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: true
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_profiles_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_profiles_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: true
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'coach_profiles_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: true;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "coach_profiles_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_profiles_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       conversation_participants: {
         Row: {
-          conversation_id: string
-          created_at: string | null
-          id: string
-          is_archived: boolean
-          is_muted: boolean
-          joined_at: string | null
-          last_read_at: string | null
-          left_at: string | null
-          role: string | null
-          updated_at: string | null
-          user_id: string
-        }
+          conversation_id: string;
+          created_at: string | null;
+          id: string;
+          is_archived: boolean;
+          is_muted: boolean;
+          joined_at: string | null;
+          last_read_at: string | null;
+          left_at: string | null;
+          role: string | null;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          conversation_id: string
-          created_at?: string | null
-          id?: string
-          is_archived?: boolean
-          is_muted?: boolean
-          joined_at?: string | null
-          last_read_at?: string | null
-          left_at?: string | null
-          role?: string | null
-          updated_at?: string | null
-          user_id: string
-        }
+          conversation_id: string;
+          created_at?: string | null;
+          id?: string;
+          is_archived?: boolean;
+          is_muted?: boolean;
+          joined_at?: string | null;
+          last_read_at?: string | null;
+          left_at?: string | null;
+          role?: string | null;
+          updated_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          conversation_id?: string
-          created_at?: string | null
-          id?: string
-          is_archived?: boolean
-          is_muted?: boolean
-          joined_at?: string | null
-          last_read_at?: string | null
-          left_at?: string | null
-          role?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
+          conversation_id?: string;
+          created_at?: string | null;
+          id?: string;
+          is_archived?: boolean;
+          is_muted?: boolean;
+          joined_at?: string | null;
+          last_read_at?: string | null;
+          left_at?: string | null;
+          role?: string | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conversation_participants_conversation_id_fkey"
-            columns: ["conversation_id"]
-            isOneToOne: false
-            referencedRelation: "conversations"
-            referencedColumns: ["id"]
+            foreignKeyName: 'conversation_participants_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "conversation_participants_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'conversation_participants_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "conversation_participants_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'conversation_participants_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "conversation_participants_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'conversation_participants_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "conversation_participants_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'conversation_participants_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "conversation_participants_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'conversation_participants_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "conversation_participants_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'conversation_participants_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       conversations: {
         Row: {
-          created_at: string | null
-          created_by: string
-          id: string
-          is_archived: boolean
-          is_muted: boolean
-          last_message_at: string | null
-          title: string | null
-          type: Database["public"]["Enums"]["conversation_type"]
-          updated_at: string | null
-        }
+          created_at: string | null;
+          created_by: string;
+          id: string;
+          is_archived: boolean;
+          is_muted: boolean;
+          last_message_at: string | null;
+          title: string | null;
+          type: Database['public']['Enums']['conversation_type'];
+          updated_at: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          created_by: string
-          id?: string
-          is_archived?: boolean
-          is_muted?: boolean
-          last_message_at?: string | null
-          title?: string | null
-          type?: Database["public"]["Enums"]["conversation_type"]
-          updated_at?: string | null
-        }
+          created_at?: string | null;
+          created_by: string;
+          id?: string;
+          is_archived?: boolean;
+          is_muted?: boolean;
+          last_message_at?: string | null;
+          title?: string | null;
+          type?: Database['public']['Enums']['conversation_type'];
+          updated_at?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          created_by?: string
-          id?: string
-          is_archived?: boolean
-          is_muted?: boolean
-          last_message_at?: string | null
-          title?: string | null
-          type?: Database["public"]["Enums"]["conversation_type"]
-          updated_at?: string | null
-        }
+          created_at?: string | null;
+          created_by?: string;
+          id?: string;
+          is_archived?: boolean;
+          is_muted?: boolean;
+          last_message_at?: string | null;
+          title?: string | null;
+          type?: Database['public']['Enums']['conversation_type'];
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "conversations_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "conversations_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "conversations_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "conversations_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "conversations_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "conversations_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       database_backups: {
         Row: {
-          backup_type: string
-          checksum: string | null
-          completed_at: string | null
-          compression_type: string | null
-          created_at: string
-          duration_ms: number | null
-          file_path: string | null
-          file_size_bytes: number | null
-          id: string
-          include_blobs: boolean | null
-          initiated_by: string | null
-          metadata: Json | null
-          started_at: string
-          status: string
-        }
+          backup_type: string;
+          checksum: string | null;
+          completed_at: string | null;
+          compression_type: string | null;
+          created_at: string;
+          duration_ms: number | null;
+          file_path: string | null;
+          file_size_bytes: number | null;
+          id: string;
+          include_blobs: boolean | null;
+          initiated_by: string | null;
+          metadata: Json | null;
+          started_at: string;
+          status: string;
+        };
         Insert: {
-          backup_type: string
-          checksum?: string | null
-          completed_at?: string | null
-          compression_type?: string | null
-          created_at?: string
-          duration_ms?: number | null
-          file_path?: string | null
-          file_size_bytes?: number | null
-          id?: string
-          include_blobs?: boolean | null
-          initiated_by?: string | null
-          metadata?: Json | null
-          started_at: string
-          status: string
-        }
+          backup_type: string;
+          checksum?: string | null;
+          completed_at?: string | null;
+          compression_type?: string | null;
+          created_at?: string;
+          duration_ms?: number | null;
+          file_path?: string | null;
+          file_size_bytes?: number | null;
+          id?: string;
+          include_blobs?: boolean | null;
+          initiated_by?: string | null;
+          metadata?: Json | null;
+          started_at: string;
+          status: string;
+        };
         Update: {
-          backup_type?: string
-          checksum?: string | null
-          completed_at?: string | null
-          compression_type?: string | null
-          created_at?: string
-          duration_ms?: number | null
-          file_path?: string | null
-          file_size_bytes?: number | null
-          id?: string
-          include_blobs?: boolean | null
-          initiated_by?: string | null
-          metadata?: Json | null
-          started_at?: string
-          status?: string
-        }
-        Relationships: []
-      }
+          backup_type?: string;
+          checksum?: string | null;
+          completed_at?: string | null;
+          compression_type?: string | null;
+          created_at?: string;
+          duration_ms?: number | null;
+          file_path?: string | null;
+          file_size_bytes?: number | null;
+          id?: string;
+          include_blobs?: boolean | null;
+          initiated_by?: string | null;
+          metadata?: Json | null;
+          started_at?: string;
+          status?: string;
+        };
+        Relationships: [];
+      };
       file_analytics_summary: {
         Row: {
-          average_download_duration_ms: number | null
-          created_at: string | null
-          date: string
-          download_methods: Json | null
-          failed_downloads: number | null
-          file_id: string
-          id: string
-          successful_downloads: number | null
-          top_countries: string[] | null
-          top_user_agents: string[] | null
-          total_bandwidth_used: number | null
-          total_downloads: number | null
-          unique_downloaders: number | null
-          unique_ip_addresses: number | null
-          updated_at: string | null
-        }
+          average_download_duration_ms: number | null;
+          created_at: string | null;
+          date: string;
+          download_methods: Json | null;
+          failed_downloads: number | null;
+          file_id: string;
+          id: string;
+          successful_downloads: number | null;
+          top_countries: string[] | null;
+          top_user_agents: string[] | null;
+          total_bandwidth_used: number | null;
+          total_downloads: number | null;
+          unique_downloaders: number | null;
+          unique_ip_addresses: number | null;
+          updated_at: string | null;
+        };
         Insert: {
-          average_download_duration_ms?: number | null
-          created_at?: string | null
-          date: string
-          download_methods?: Json | null
-          failed_downloads?: number | null
-          file_id: string
-          id?: string
-          successful_downloads?: number | null
-          top_countries?: string[] | null
-          top_user_agents?: string[] | null
-          total_bandwidth_used?: number | null
-          total_downloads?: number | null
-          unique_downloaders?: number | null
-          unique_ip_addresses?: number | null
-          updated_at?: string | null
-        }
+          average_download_duration_ms?: number | null;
+          created_at?: string | null;
+          date: string;
+          download_methods?: Json | null;
+          failed_downloads?: number | null;
+          file_id: string;
+          id?: string;
+          successful_downloads?: number | null;
+          top_countries?: string[] | null;
+          top_user_agents?: string[] | null;
+          total_bandwidth_used?: number | null;
+          total_downloads?: number | null;
+          unique_downloaders?: number | null;
+          unique_ip_addresses?: number | null;
+          updated_at?: string | null;
+        };
         Update: {
-          average_download_duration_ms?: number | null
-          created_at?: string | null
-          date?: string
-          download_methods?: Json | null
-          failed_downloads?: number | null
-          file_id?: string
-          id?: string
-          successful_downloads?: number | null
-          top_countries?: string[] | null
-          top_user_agents?: string[] | null
-          total_bandwidth_used?: number | null
-          total_downloads?: number | null
-          unique_downloaders?: number | null
-          unique_ip_addresses?: number | null
-          updated_at?: string | null
-        }
+          average_download_duration_ms?: number | null;
+          created_at?: string | null;
+          date?: string;
+          download_methods?: Json | null;
+          failed_downloads?: number | null;
+          file_id?: string;
+          id?: string;
+          successful_downloads?: number | null;
+          top_countries?: string[] | null;
+          top_user_agents?: string[] | null;
+          total_bandwidth_used?: number | null;
+          total_downloads?: number | null;
+          unique_downloaders?: number | null;
+          unique_ip_addresses?: number | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_analytics_summary_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_analytics_summary_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_analytics_summary_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_analytics_summary_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_download_logs: {
         Row: {
-          bandwidth_used: number | null
-          city: string | null
-          client_info: Json | null
-          country_code: string | null
-          download_duration_ms: number | null
-          download_type: string
-          downloaded_at: string | null
-          downloaded_by: string | null
-          failure_reason: string | null
-          file_id: string
-          file_size_at_download: number | null
-          id: string
-          ip_address: unknown | null
-          metadata: Json | null
-          share_id: string | null
-          success: boolean
-          user_agent: string | null
-        }
+          bandwidth_used: number | null;
+          city: string | null;
+          client_info: Json | null;
+          country_code: string | null;
+          download_duration_ms: number | null;
+          download_type: string;
+          downloaded_at: string | null;
+          downloaded_by: string | null;
+          failure_reason: string | null;
+          file_id: string;
+          file_size_at_download: number | null;
+          id: string;
+          ip_address: unknown | null;
+          metadata: Json | null;
+          share_id: string | null;
+          success: boolean;
+          user_agent: string | null;
+        };
         Insert: {
-          bandwidth_used?: number | null
-          city?: string | null
-          client_info?: Json | null
-          country_code?: string | null
-          download_duration_ms?: number | null
-          download_type?: string
-          downloaded_at?: string | null
-          downloaded_by?: string | null
-          failure_reason?: string | null
-          file_id: string
-          file_size_at_download?: number | null
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          share_id?: string | null
-          success?: boolean
-          user_agent?: string | null
-        }
+          bandwidth_used?: number | null;
+          city?: string | null;
+          client_info?: Json | null;
+          country_code?: string | null;
+          download_duration_ms?: number | null;
+          download_type?: string;
+          downloaded_at?: string | null;
+          downloaded_by?: string | null;
+          failure_reason?: string | null;
+          file_id: string;
+          file_size_at_download?: number | null;
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          share_id?: string | null;
+          success?: boolean;
+          user_agent?: string | null;
+        };
         Update: {
-          bandwidth_used?: number | null
-          city?: string | null
-          client_info?: Json | null
-          country_code?: string | null
-          download_duration_ms?: number | null
-          download_type?: string
-          downloaded_at?: string | null
-          downloaded_by?: string | null
-          failure_reason?: string | null
-          file_id?: string
-          file_size_at_download?: number | null
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          share_id?: string | null
-          success?: boolean
-          user_agent?: string | null
-        }
+          bandwidth_used?: number | null;
+          city?: string | null;
+          client_info?: Json | null;
+          country_code?: string | null;
+          download_duration_ms?: number | null;
+          download_type?: string;
+          downloaded_at?: string | null;
+          downloaded_by?: string | null;
+          failure_reason?: string | null;
+          file_id?: string;
+          file_size_at_download?: number | null;
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          share_id?: string | null;
+          success?: boolean;
+          user_agent?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_download_logs_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_download_logs_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_download_logs_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_download_logs_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_security_events: {
         Row: {
-          created_at: string | null
-          event_details: Json | null
-          event_type: string
-          file_hash: string | null
-          file_id: string | null
-          file_name: string | null
-          file_size: number | null
-          file_type: string | null
-          id: string
-          ip_address: unknown
-          quarantined: boolean | null
-          severity: Database["public"]["Enums"]["security_severity"]
-          user_id: string | null
-        }
+          created_at: string | null;
+          event_details: Json | null;
+          event_type: string;
+          file_hash: string | null;
+          file_id: string | null;
+          file_name: string | null;
+          file_size: number | null;
+          file_type: string | null;
+          id: string;
+          ip_address: unknown;
+          quarantined: boolean | null;
+          severity: Database['public']['Enums']['security_severity'];
+          user_id: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          event_details?: Json | null
-          event_type: string
-          file_hash?: string | null
-          file_id?: string | null
-          file_name?: string | null
-          file_size?: number | null
-          file_type?: string | null
-          id?: string
-          ip_address: unknown
-          quarantined?: boolean | null
-          severity?: Database["public"]["Enums"]["security_severity"]
-          user_id?: string | null
-        }
+          created_at?: string | null;
+          event_details?: Json | null;
+          event_type: string;
+          file_hash?: string | null;
+          file_id?: string | null;
+          file_name?: string | null;
+          file_size?: number | null;
+          file_type?: string | null;
+          id?: string;
+          ip_address: unknown;
+          quarantined?: boolean | null;
+          severity?: Database['public']['Enums']['security_severity'];
+          user_id?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          event_details?: Json | null
-          event_type?: string
-          file_hash?: string | null
-          file_id?: string | null
-          file_name?: string | null
-          file_size?: number | null
-          file_type?: string | null
-          id?: string
-          ip_address?: unknown
-          quarantined?: boolean | null
-          severity?: Database["public"]["Enums"]["security_severity"]
-          user_id?: string | null
-        }
+          created_at?: string | null;
+          event_details?: Json | null;
+          event_type?: string;
+          file_hash?: string | null;
+          file_id?: string | null;
+          file_name?: string | null;
+          file_size?: number | null;
+          file_type?: string | null;
+          id?: string;
+          ip_address?: unknown;
+          quarantined?: boolean | null;
+          severity?: Database['public']['Enums']['security_severity'];
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_security_events_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_security_events_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_security_events_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_security_events_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_security_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_security_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_security_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_security_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_security_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_security_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_security_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_security_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_security_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_security_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_security_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_security_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_shares: {
         Row: {
-          access_count: number
-          created_at: string | null
-          expires_at: string | null
-          file_id: string
-          id: string
-          last_accessed_at: string | null
-          permission_type: Database["public"]["Enums"]["file_permission_type"]
-          shared_by: string
-          shared_with: string
-        }
+          access_count: number;
+          created_at: string | null;
+          expires_at: string | null;
+          file_id: string;
+          id: string;
+          last_accessed_at: string | null;
+          permission_type: Database['public']['Enums']['file_permission_type'];
+          shared_by: string;
+          shared_with: string;
+        };
         Insert: {
-          access_count?: number
-          created_at?: string | null
-          expires_at?: string | null
-          file_id: string
-          id?: string
-          last_accessed_at?: string | null
-          permission_type?: Database["public"]["Enums"]["file_permission_type"]
-          shared_by: string
-          shared_with: string
-        }
+          access_count?: number;
+          created_at?: string | null;
+          expires_at?: string | null;
+          file_id: string;
+          id?: string;
+          last_accessed_at?: string | null;
+          permission_type?: Database['public']['Enums']['file_permission_type'];
+          shared_by: string;
+          shared_with: string;
+        };
         Update: {
-          access_count?: number
-          created_at?: string | null
-          expires_at?: string | null
-          file_id?: string
-          id?: string
-          last_accessed_at?: string | null
-          permission_type?: Database["public"]["Enums"]["file_permission_type"]
-          shared_by?: string
-          shared_with?: string
-        }
+          access_count?: number;
+          created_at?: string | null;
+          expires_at?: string | null;
+          file_id?: string;
+          id?: string;
+          last_accessed_at?: string | null;
+          permission_type?: Database['public']['Enums']['file_permission_type'];
+          shared_by?: string;
+          shared_with?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_shares_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_shares_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_shares_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_shares_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_uploads: {
         Row: {
-          auto_version_on_update: boolean | null
-          bucket_name: string
-          created_at: string | null
-          current_version: number | null
-          description: string | null
-          download_count: number
-          file_category: Database["public"]["Enums"]["file_category"]
-          file_size: number
-          file_type: string
-          filename: string
-          id: string
-          is_shared: boolean
-          max_versions: number | null
-          original_filename: string
-          session_id: string | null
-          storage_path: string
-          tags: string[] | null
-          updated_at: string | null
-          user_id: string
-          version_count: number | null
-          versioning_enabled: boolean | null
-        }
+          auto_version_on_update: boolean | null;
+          bucket_name: string;
+          created_at: string | null;
+          current_version: number | null;
+          description: string | null;
+          download_count: number;
+          file_category: Database['public']['Enums']['file_category'];
+          file_size: number;
+          file_type: string;
+          filename: string;
+          id: string;
+          is_shared: boolean;
+          max_versions: number | null;
+          original_filename: string;
+          session_id: string | null;
+          storage_path: string;
+          tags: string[] | null;
+          updated_at: string | null;
+          user_id: string;
+          version_count: number | null;
+          versioning_enabled: boolean | null;
+        };
         Insert: {
-          auto_version_on_update?: boolean | null
-          bucket_name: string
-          created_at?: string | null
-          current_version?: number | null
-          description?: string | null
-          download_count?: number
-          file_category?: Database["public"]["Enums"]["file_category"]
-          file_size: number
-          file_type: string
-          filename: string
-          id?: string
-          is_shared?: boolean
-          max_versions?: number | null
-          original_filename: string
-          session_id?: string | null
-          storage_path: string
-          tags?: string[] | null
-          updated_at?: string | null
-          user_id: string
-          version_count?: number | null
-          versioning_enabled?: boolean | null
-        }
+          auto_version_on_update?: boolean | null;
+          bucket_name: string;
+          created_at?: string | null;
+          current_version?: number | null;
+          description?: string | null;
+          download_count?: number;
+          file_category?: Database['public']['Enums']['file_category'];
+          file_size: number;
+          file_type: string;
+          filename: string;
+          id?: string;
+          is_shared?: boolean;
+          max_versions?: number | null;
+          original_filename: string;
+          session_id?: string | null;
+          storage_path: string;
+          tags?: string[] | null;
+          updated_at?: string | null;
+          user_id: string;
+          version_count?: number | null;
+          versioning_enabled?: boolean | null;
+        };
         Update: {
-          auto_version_on_update?: boolean | null
-          bucket_name?: string
-          created_at?: string | null
-          current_version?: number | null
-          description?: string | null
-          download_count?: number
-          file_category?: Database["public"]["Enums"]["file_category"]
-          file_size?: number
-          file_type?: string
-          filename?: string
-          id?: string
-          is_shared?: boolean
-          max_versions?: number | null
-          original_filename?: string
-          session_id?: string | null
-          storage_path?: string
-          tags?: string[] | null
-          updated_at?: string | null
-          user_id?: string
-          version_count?: number | null
-          versioning_enabled?: boolean | null
-        }
+          auto_version_on_update?: boolean | null;
+          bucket_name?: string;
+          created_at?: string | null;
+          current_version?: number | null;
+          description?: string | null;
+          download_count?: number;
+          file_category?: Database['public']['Enums']['file_category'];
+          file_size?: number;
+          file_type?: string;
+          filename?: string;
+          id?: string;
+          is_shared?: boolean;
+          max_versions?: number | null;
+          original_filename?: string;
+          session_id?: string | null;
+          storage_path?: string;
+          tags?: string[] | null;
+          updated_at?: string | null;
+          user_id?: string;
+          version_count?: number | null;
+          versioning_enabled?: boolean | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_uploads_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_uploads_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_uploads_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_uploads_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_version_comparisons: {
         Row: {
-          created_at: string | null
-          created_by: string | null
-          id: string
-          result: Json | null
-          version_a_id: string
-          version_b_id: string
-        }
+          created_at: string | null;
+          created_by: string | null;
+          id: string;
+          result: Json | null;
+          version_a_id: string;
+          version_b_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          created_by?: string | null
-          id?: string
-          result?: Json | null
-          version_a_id: string
-          version_b_id: string
-        }
+          created_at?: string | null;
+          created_by?: string | null;
+          id?: string;
+          result?: Json | null;
+          version_a_id: string;
+          version_b_id: string;
+        };
         Update: {
-          created_at?: string | null
-          created_by?: string | null
-          id?: string
-          result?: Json | null
-          version_a_id?: string
-          version_b_id?: string
-        }
+          created_at?: string | null;
+          created_by?: string | null;
+          id?: string;
+          result?: Json | null;
+          version_a_id?: string;
+          version_b_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_version_comparisons_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_version_comparisons_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_version_comparisons_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_version_comparisons_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_version_comparisons_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_version_comparisons_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_comparisons_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_version_a_id_fkey"
-            columns: ["version_a_id"]
-            isOneToOne: false
-            referencedRelation: "file_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_comparisons_version_a_id_fkey';
+            columns: ['version_a_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_versions';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_version_comparisons_version_b_id_fkey"
-            columns: ["version_b_id"]
-            isOneToOne: false
-            referencedRelation: "file_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_comparisons_version_b_id_fkey';
+            columns: ['version_b_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_versions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_version_shares: {
         Row: {
-          access_count: number | null
-          created_at: string | null
-          expires_at: string | null
-          file_id: string
-          id: string
-          last_accessed_at: string | null
-          message: string | null
-          permission_type: string
-          shared_by: string
-          shared_with: string
-          updated_at: string | null
-          version_id: string
-        }
+          access_count: number | null;
+          created_at: string | null;
+          expires_at: string | null;
+          file_id: string;
+          id: string;
+          last_accessed_at: string | null;
+          message: string | null;
+          permission_type: string;
+          shared_by: string;
+          shared_with: string;
+          updated_at: string | null;
+          version_id: string;
+        };
         Insert: {
-          access_count?: number | null
-          created_at?: string | null
-          expires_at?: string | null
-          file_id: string
-          id?: string
-          last_accessed_at?: string | null
-          message?: string | null
-          permission_type: string
-          shared_by: string
-          shared_with: string
-          updated_at?: string | null
-          version_id: string
-        }
+          access_count?: number | null;
+          created_at?: string | null;
+          expires_at?: string | null;
+          file_id: string;
+          id?: string;
+          last_accessed_at?: string | null;
+          message?: string | null;
+          permission_type: string;
+          shared_by: string;
+          shared_with: string;
+          updated_at?: string | null;
+          version_id: string;
+        };
         Update: {
-          access_count?: number | null
-          created_at?: string | null
-          expires_at?: string | null
-          file_id?: string
-          id?: string
-          last_accessed_at?: string | null
-          message?: string | null
-          permission_type?: string
-          shared_by?: string
-          shared_with?: string
-          updated_at?: string | null
-          version_id?: string
-        }
+          access_count?: number | null;
+          created_at?: string | null;
+          expires_at?: string | null;
+          file_id?: string;
+          id?: string;
+          last_accessed_at?: string | null;
+          message?: string | null;
+          permission_type?: string;
+          shared_by?: string;
+          shared_with?: string;
+          updated_at?: string | null;
+          version_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_version_shares_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_shares_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_version_shares_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_shares_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_version_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_version_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_version_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_version_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_version_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_by_fkey"
-            columns: ["shared_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_shares_shared_by_fkey';
+            columns: ['shared_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_version_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_version_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_version_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_version_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_version_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_version_shares_shared_with_fkey"
-            columns: ["shared_with"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_shares_shared_with_fkey';
+            columns: ['shared_with'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_version_shares_version_id_fkey"
-            columns: ["version_id"]
-            isOneToOne: false
-            referencedRelation: "file_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_version_shares_version_id_fkey';
+            columns: ['version_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_versions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       file_versions: {
         Row: {
-          change_summary: string | null
-          created_at: string | null
-          created_by: string
-          description: string | null
-          diff_metadata: Json | null
-          file_hash: string
-          file_id: string
-          file_size: number
-          file_type: string
-          filename: string
-          id: string
-          is_current_version: boolean | null
-          is_major_version: boolean | null
-          original_filename: string
-          storage_path: string
-          version_number: number
-        }
+          change_summary: string | null;
+          created_at: string | null;
+          created_by: string;
+          description: string | null;
+          diff_metadata: Json | null;
+          file_hash: string;
+          file_id: string;
+          file_size: number;
+          file_type: string;
+          filename: string;
+          id: string;
+          is_current_version: boolean | null;
+          is_major_version: boolean | null;
+          original_filename: string;
+          storage_path: string;
+          version_number: number;
+        };
         Insert: {
-          change_summary?: string | null
-          created_at?: string | null
-          created_by: string
-          description?: string | null
-          diff_metadata?: Json | null
-          file_hash: string
-          file_id: string
-          file_size: number
-          file_type: string
-          filename: string
-          id?: string
-          is_current_version?: boolean | null
-          is_major_version?: boolean | null
-          original_filename: string
-          storage_path: string
-          version_number: number
-        }
+          change_summary?: string | null;
+          created_at?: string | null;
+          created_by: string;
+          description?: string | null;
+          diff_metadata?: Json | null;
+          file_hash: string;
+          file_id: string;
+          file_size: number;
+          file_type: string;
+          filename: string;
+          id?: string;
+          is_current_version?: boolean | null;
+          is_major_version?: boolean | null;
+          original_filename: string;
+          storage_path: string;
+          version_number: number;
+        };
         Update: {
-          change_summary?: string | null
-          created_at?: string | null
-          created_by?: string
-          description?: string | null
-          diff_metadata?: Json | null
-          file_hash?: string
-          file_id?: string
-          file_size?: number
-          file_type?: string
-          filename?: string
-          id?: string
-          is_current_version?: boolean | null
-          is_major_version?: boolean | null
-          original_filename?: string
-          storage_path?: string
-          version_number?: number
-        }
+          change_summary?: string | null;
+          created_at?: string | null;
+          created_by?: string;
+          description?: string | null;
+          diff_metadata?: Json | null;
+          file_hash?: string;
+          file_id?: string;
+          file_size?: number;
+          file_type?: string;
+          filename?: string;
+          id?: string;
+          is_current_version?: boolean | null;
+          is_major_version?: boolean | null;
+          original_filename?: string;
+          storage_path?: string;
+          version_number?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_versions_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_versions_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_versions_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_versions_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_versions_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_versions_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_versions_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_versions_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_versions_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_versions_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_versions_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_versions_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_versions_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_versions_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_versions_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_versions_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       goal_milestones: {
         Row: {
-          completed_at: string | null
-          created_at: string | null
-          description: string | null
-          goal_id: string
-          id: string
-          notes: string | null
-          target_date: string | null
-          title: string
-          updated_at: string | null
-        }
+          completed_at: string | null;
+          created_at: string | null;
+          description: string | null;
+          goal_id: string;
+          id: string;
+          notes: string | null;
+          target_date: string | null;
+          title: string;
+          updated_at: string | null;
+        };
         Insert: {
-          completed_at?: string | null
-          created_at?: string | null
-          description?: string | null
-          goal_id: string
-          id?: string
-          notes?: string | null
-          target_date?: string | null
-          title: string
-          updated_at?: string | null
-        }
+          completed_at?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          goal_id: string;
+          id?: string;
+          notes?: string | null;
+          target_date?: string | null;
+          title: string;
+          updated_at?: string | null;
+        };
         Update: {
-          completed_at?: string | null
-          created_at?: string | null
-          description?: string | null
-          goal_id?: string
-          id?: string
-          notes?: string | null
-          target_date?: string | null
-          title?: string
-          updated_at?: string | null
-        }
+          completed_at?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          goal_id?: string;
+          id?: string;
+          notes?: string | null;
+          target_date?: string | null;
+          title?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "goal_milestones_goal_id_fkey"
-            columns: ["goal_id"]
-            isOneToOne: false
-            referencedRelation: "client_goals"
-            referencedColumns: ["id"]
+            foreignKeyName: 'goal_milestones_goal_id_fkey';
+            columns: ['goal_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_goals';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       maintenance_logs: {
         Row: {
-          action: Database["public"]["Enums"]["maintenance_action_type"]
-          completed_at: string | null
-          created_at: string
-          duration_ms: number | null
-          error_details: Json | null
-          error_message: string | null
-          id: string
-          initiated_by: string | null
-          initiated_by_email: string | null
-          parameters: Json | null
-          result: Json | null
-          started_at: string
-          status: Database["public"]["Enums"]["maintenance_status"]
-          system_info: Json | null
-          updated_at: string
-        }
+          action: Database['public']['Enums']['maintenance_action_type'];
+          completed_at: string | null;
+          created_at: string;
+          duration_ms: number | null;
+          error_details: Json | null;
+          error_message: string | null;
+          id: string;
+          initiated_by: string | null;
+          initiated_by_email: string | null;
+          parameters: Json | null;
+          result: Json | null;
+          started_at: string;
+          status: Database['public']['Enums']['maintenance_status'];
+          system_info: Json | null;
+          updated_at: string;
+        };
         Insert: {
-          action: Database["public"]["Enums"]["maintenance_action_type"]
-          completed_at?: string | null
-          created_at?: string
-          duration_ms?: number | null
-          error_details?: Json | null
-          error_message?: string | null
-          id?: string
-          initiated_by?: string | null
-          initiated_by_email?: string | null
-          parameters?: Json | null
-          result?: Json | null
-          started_at?: string
-          status?: Database["public"]["Enums"]["maintenance_status"]
-          system_info?: Json | null
-          updated_at?: string
-        }
+          action: Database['public']['Enums']['maintenance_action_type'];
+          completed_at?: string | null;
+          created_at?: string;
+          duration_ms?: number | null;
+          error_details?: Json | null;
+          error_message?: string | null;
+          id?: string;
+          initiated_by?: string | null;
+          initiated_by_email?: string | null;
+          parameters?: Json | null;
+          result?: Json | null;
+          started_at?: string;
+          status?: Database['public']['Enums']['maintenance_status'];
+          system_info?: Json | null;
+          updated_at?: string;
+        };
         Update: {
-          action?: Database["public"]["Enums"]["maintenance_action_type"]
-          completed_at?: string | null
-          created_at?: string
-          duration_ms?: number | null
-          error_details?: Json | null
-          error_message?: string | null
-          id?: string
-          initiated_by?: string | null
-          initiated_by_email?: string | null
-          parameters?: Json | null
-          result?: Json | null
-          started_at?: string
-          status?: Database["public"]["Enums"]["maintenance_status"]
-          system_info?: Json | null
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          action?: Database['public']['Enums']['maintenance_action_type'];
+          completed_at?: string | null;
+          created_at?: string;
+          duration_ms?: number | null;
+          error_details?: Json | null;
+          error_message?: string | null;
+          id?: string;
+          initiated_by?: string | null;
+          initiated_by_email?: string | null;
+          parameters?: Json | null;
+          result?: Json | null;
+          started_at?: string;
+          status?: Database['public']['Enums']['maintenance_status'];
+          system_info?: Json | null;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       message_attachments: {
         Row: {
-          attachment_type: Database["public"]["Enums"]["attachment_type"]
-          created_at: string | null
-          file_name: string
-          file_size: number
-          file_type: string
-          id: string
-          message_id: string
-          metadata: Json | null
-          thumbnail_url: string | null
-          updated_at: string | null
-          url: string
-        }
+          attachment_type: Database['public']['Enums']['attachment_type'];
+          created_at: string | null;
+          file_name: string;
+          file_size: number;
+          file_type: string;
+          id: string;
+          message_id: string;
+          metadata: Json | null;
+          thumbnail_url: string | null;
+          updated_at: string | null;
+          url: string;
+        };
         Insert: {
-          attachment_type?: Database["public"]["Enums"]["attachment_type"]
-          created_at?: string | null
-          file_name: string
-          file_size: number
-          file_type: string
-          id?: string
-          message_id: string
-          metadata?: Json | null
-          thumbnail_url?: string | null
-          updated_at?: string | null
-          url: string
-        }
+          attachment_type?: Database['public']['Enums']['attachment_type'];
+          created_at?: string | null;
+          file_name: string;
+          file_size: number;
+          file_type: string;
+          id?: string;
+          message_id: string;
+          metadata?: Json | null;
+          thumbnail_url?: string | null;
+          updated_at?: string | null;
+          url: string;
+        };
         Update: {
-          attachment_type?: Database["public"]["Enums"]["attachment_type"]
-          created_at?: string | null
-          file_name?: string
-          file_size?: number
-          file_type?: string
-          id?: string
-          message_id?: string
-          metadata?: Json | null
-          thumbnail_url?: string | null
-          updated_at?: string | null
-          url?: string
-        }
+          attachment_type?: Database['public']['Enums']['attachment_type'];
+          created_at?: string | null;
+          file_name?: string;
+          file_size?: number;
+          file_type?: string;
+          id?: string;
+          message_id?: string;
+          metadata?: Json | null;
+          thumbnail_url?: string | null;
+          updated_at?: string | null;
+          url?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "message_attachments_message_id_fkey"
-            columns: ["message_id"]
-            isOneToOne: false
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: 'message_attachments_message_id_fkey';
+            columns: ['message_id'];
+            isOneToOne: false;
+            referencedRelation: 'messages';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       message_reactions: {
         Row: {
-          created_at: string | null
-          emoji: string
-          id: string
-          message_id: string
-          user_id: string
-        }
+          created_at: string | null;
+          emoji: string;
+          id: string;
+          message_id: string;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          emoji: string
-          id?: string
-          message_id: string
-          user_id: string
-        }
+          created_at?: string | null;
+          emoji: string;
+          id?: string;
+          message_id: string;
+          user_id: string;
+        };
         Update: {
-          created_at?: string | null
-          emoji?: string
-          id?: string
-          message_id?: string
-          user_id?: string
-        }
+          created_at?: string | null;
+          emoji?: string;
+          id?: string;
+          message_id?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "message_reactions_message_id_fkey"
-            columns: ["message_id"]
-            isOneToOne: false
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: 'message_reactions_message_id_fkey';
+            columns: ['message_id'];
+            isOneToOne: false;
+            referencedRelation: 'messages';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "message_reactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'message_reactions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "message_reactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'message_reactions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "message_reactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'message_reactions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "message_reactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'message_reactions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "message_reactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'message_reactions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "message_reactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'message_reactions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       message_read_receipts: {
         Row: {
-          id: string
-          message_id: string
-          read_at: string | null
-          user_id: string
-        }
+          id: string;
+          message_id: string;
+          read_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          id?: string
-          message_id: string
-          read_at?: string | null
-          user_id: string
-        }
+          id?: string;
+          message_id: string;
+          read_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          id?: string
-          message_id?: string
-          read_at?: string | null
-          user_id?: string
-        }
+          id?: string;
+          message_id?: string;
+          read_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "message_read_receipts_message_id_fkey"
-            columns: ["message_id"]
-            isOneToOne: false
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: 'message_read_receipts_message_id_fkey';
+            columns: ['message_id'];
+            isOneToOne: false;
+            referencedRelation: 'messages';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "message_read_receipts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'message_read_receipts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "message_read_receipts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'message_read_receipts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "message_read_receipts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'message_read_receipts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "message_read_receipts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'message_read_receipts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "message_read_receipts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'message_read_receipts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "message_read_receipts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'message_read_receipts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       messages: {
         Row: {
-          content: string | null
-          conversation_id: string
-          created_at: string | null
-          delivered_at: string | null
-          edited_at: string | null
-          id: string
-          is_edited: boolean
-          metadata: Json | null
-          reply_to_id: string | null
-          sender_id: string
-          status: Database["public"]["Enums"]["message_status"]
-          type: Database["public"]["Enums"]["message_type"]
-          updated_at: string | null
-        }
+          content: string | null;
+          conversation_id: string;
+          created_at: string | null;
+          delivered_at: string | null;
+          edited_at: string | null;
+          id: string;
+          is_edited: boolean;
+          metadata: Json | null;
+          reply_to_id: string | null;
+          sender_id: string;
+          status: Database['public']['Enums']['message_status'];
+          type: Database['public']['Enums']['message_type'];
+          updated_at: string | null;
+        };
         Insert: {
-          content?: string | null
-          conversation_id: string
-          created_at?: string | null
-          delivered_at?: string | null
-          edited_at?: string | null
-          id?: string
-          is_edited?: boolean
-          metadata?: Json | null
-          reply_to_id?: string | null
-          sender_id: string
-          status?: Database["public"]["Enums"]["message_status"]
-          type?: Database["public"]["Enums"]["message_type"]
-          updated_at?: string | null
-        }
+          content?: string | null;
+          conversation_id: string;
+          created_at?: string | null;
+          delivered_at?: string | null;
+          edited_at?: string | null;
+          id?: string;
+          is_edited?: boolean;
+          metadata?: Json | null;
+          reply_to_id?: string | null;
+          sender_id: string;
+          status?: Database['public']['Enums']['message_status'];
+          type?: Database['public']['Enums']['message_type'];
+          updated_at?: string | null;
+        };
         Update: {
-          content?: string | null
-          conversation_id?: string
-          created_at?: string | null
-          delivered_at?: string | null
-          edited_at?: string | null
-          id?: string
-          is_edited?: boolean
-          metadata?: Json | null
-          reply_to_id?: string | null
-          sender_id?: string
-          status?: Database["public"]["Enums"]["message_status"]
-          type?: Database["public"]["Enums"]["message_type"]
-          updated_at?: string | null
-        }
+          content?: string | null;
+          conversation_id?: string;
+          created_at?: string | null;
+          delivered_at?: string | null;
+          edited_at?: string | null;
+          id?: string;
+          is_edited?: boolean;
+          metadata?: Json | null;
+          reply_to_id?: string | null;
+          sender_id?: string;
+          status?: Database['public']['Enums']['message_status'];
+          type?: Database['public']['Enums']['message_type'];
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "messages_conversation_id_fkey"
-            columns: ["conversation_id"]
-            isOneToOne: false
-            referencedRelation: "conversations"
-            referencedColumns: ["id"]
+            foreignKeyName: 'messages_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "messages_reply_to_id_fkey"
-            columns: ["reply_to_id"]
-            isOneToOne: false
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: 'messages_reply_to_id_fkey';
+            columns: ['reply_to_id'];
+            isOneToOne: false;
+            referencedRelation: 'messages';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_attempts: {
         Row: {
-          created_at: string | null
-          error_message: string | null
-          id: string
-          ip_address: unknown | null
-          method: Database["public"]["Enums"]["mfa_method"]
-          success: boolean
-          user_agent: string | null
-          user_id: string
-        }
+          created_at: string | null;
+          error_message: string | null;
+          id: string;
+          ip_address: unknown | null;
+          method: Database['public']['Enums']['mfa_method'];
+          success: boolean;
+          user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          error_message?: string | null
-          id?: string
-          ip_address?: unknown | null
-          method: Database["public"]["Enums"]["mfa_method"]
-          success: boolean
-          user_agent?: string | null
-          user_id: string
-        }
+          created_at?: string | null;
+          error_message?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          method: Database['public']['Enums']['mfa_method'];
+          success: boolean;
+          user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          created_at?: string | null
-          error_message?: string | null
-          id?: string
-          ip_address?: unknown | null
-          method?: Database["public"]["Enums"]["mfa_method"]
-          success?: boolean
-          user_agent?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          error_message?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          method?: Database['public']['Enums']['mfa_method'];
+          success?: boolean;
+          user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_audit_log: {
         Row: {
-          action: string
-          created_at: string | null
-          details: Json | null
-          id: string
-          ip_address: unknown | null
-          user_agent: string | null
-          user_id: string
-        }
+          action: string;
+          created_at: string | null;
+          details: Json | null;
+          id: string;
+          ip_address: unknown | null;
+          user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          action: string
-          created_at?: string | null
-          details?: Json | null
-          id?: string
-          ip_address?: unknown | null
-          user_agent?: string | null
-          user_id: string
-        }
+          action: string;
+          created_at?: string | null;
+          details?: Json | null;
+          id?: string;
+          ip_address?: unknown | null;
+          user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          action?: string
-          created_at?: string | null
-          details?: Json | null
-          id?: string
-          ip_address?: unknown | null
-          user_agent?: string | null
-          user_id?: string
-        }
+          action?: string;
+          created_at?: string | null;
+          details?: Json | null;
+          id?: string;
+          ip_address?: unknown | null;
+          user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_backup_codes: {
         Row: {
-          code_hash: string
-          code_salt: string
-          created_at: string | null
-          expires_at: string
-          id: string
-          status: Database["public"]["Enums"]["backup_code_status"]
-          used_at: string | null
-          used_ip: unknown | null
-          used_user_agent: string | null
-          user_id: string
-        }
+          code_hash: string;
+          code_salt: string;
+          created_at: string | null;
+          expires_at: string;
+          id: string;
+          status: Database['public']['Enums']['backup_code_status'];
+          used_at: string | null;
+          used_ip: unknown | null;
+          used_user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          code_hash: string
-          code_salt: string
-          created_at?: string | null
-          expires_at?: string
-          id?: string
-          status?: Database["public"]["Enums"]["backup_code_status"]
-          used_at?: string | null
-          used_ip?: unknown | null
-          used_user_agent?: string | null
-          user_id: string
-        }
+          code_hash: string;
+          code_salt: string;
+          created_at?: string | null;
+          expires_at?: string;
+          id?: string;
+          status?: Database['public']['Enums']['backup_code_status'];
+          used_at?: string | null;
+          used_ip?: unknown | null;
+          used_user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          code_hash?: string
-          code_salt?: string
-          created_at?: string | null
-          expires_at?: string
-          id?: string
-          status?: Database["public"]["Enums"]["backup_code_status"]
-          used_at?: string | null
-          used_ip?: unknown | null
-          used_user_agent?: string | null
-          user_id?: string
-        }
+          code_hash?: string;
+          code_salt?: string;
+          created_at?: string | null;
+          expires_at?: string;
+          id?: string;
+          status?: Database['public']['Enums']['backup_code_status'];
+          used_at?: string | null;
+          used_ip?: unknown | null;
+          used_user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_backup_codes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_backup_codes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_backup_codes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_backup_codes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_backup_codes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_backup_codes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_backup_codes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_backup_codes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_backup_codes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_backup_codes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_backup_codes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_backup_codes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_events: {
         Row: {
-          created_at: string | null
-          event_type: Database["public"]["Enums"]["mfa_event_type"]
-          id: string
-          ip_address: unknown | null
-          metadata: Json | null
-          user_agent: string | null
-          user_id: string
-        }
+          created_at: string | null;
+          event_type: Database['public']['Enums']['mfa_event_type'];
+          id: string;
+          ip_address: unknown | null;
+          metadata: Json | null;
+          user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          event_type: Database["public"]["Enums"]["mfa_event_type"]
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          user_agent?: string | null
-          user_id: string
-        }
+          created_at?: string | null;
+          event_type: Database['public']['Enums']['mfa_event_type'];
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          created_at?: string | null
-          event_type?: Database["public"]["Enums"]["mfa_event_type"]
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          user_agent?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          event_type?: Database['public']['Enums']['mfa_event_type'];
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_events_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_events_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_sessions: {
         Row: {
-          created_at: string | null
-          device_fingerprint: string | null
-          expires_at: string
-          id: string
-          ip_address: unknown | null
-          mfa_verified: boolean | null
-          password_verified: boolean | null
-          session_token: string
-          updated_at: string | null
-          user_agent: string | null
-          user_id: string
-          verified: boolean
-        }
+          created_at: string | null;
+          device_fingerprint: string | null;
+          expires_at: string;
+          id: string;
+          ip_address: unknown | null;
+          mfa_verified: boolean | null;
+          password_verified: boolean | null;
+          session_token: string;
+          updated_at: string | null;
+          user_agent: string | null;
+          user_id: string;
+          verified: boolean;
+        };
         Insert: {
-          created_at?: string | null
-          device_fingerprint?: string | null
-          expires_at: string
-          id?: string
-          ip_address?: unknown | null
-          mfa_verified?: boolean | null
-          password_verified?: boolean | null
-          session_token: string
-          updated_at?: string | null
-          user_agent?: string | null
-          user_id: string
-          verified?: boolean
-        }
+          created_at?: string | null;
+          device_fingerprint?: string | null;
+          expires_at: string;
+          id?: string;
+          ip_address?: unknown | null;
+          mfa_verified?: boolean | null;
+          password_verified?: boolean | null;
+          session_token: string;
+          updated_at?: string | null;
+          user_agent?: string | null;
+          user_id: string;
+          verified?: boolean;
+        };
         Update: {
-          created_at?: string | null
-          device_fingerprint?: string | null
-          expires_at?: string
-          id?: string
-          ip_address?: unknown | null
-          mfa_verified?: boolean | null
-          password_verified?: boolean | null
-          session_token?: string
-          updated_at?: string | null
-          user_agent?: string | null
-          user_id?: string
-          verified?: boolean
-        }
+          created_at?: string | null;
+          device_fingerprint?: string | null;
+          expires_at?: string;
+          id?: string;
+          ip_address?: unknown | null;
+          mfa_verified?: boolean | null;
+          password_verified?: boolean | null;
+          session_token?: string;
+          updated_at?: string | null;
+          user_agent?: string | null;
+          user_id?: string;
+          verified?: boolean;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_system_config: {
         Row: {
-          description: string | null
-          id: string
-          setting_key: string
-          setting_value: Json
-          updated_at: string | null
-          updated_by: string | null
-        }
+          description: string | null;
+          id: string;
+          setting_key: string;
+          setting_value: Json;
+          updated_at: string | null;
+          updated_by: string | null;
+        };
         Insert: {
-          description?: string | null
-          id?: string
-          setting_key: string
-          setting_value: Json
-          updated_at?: string | null
-          updated_by?: string | null
-        }
+          description?: string | null;
+          id?: string;
+          setting_key: string;
+          setting_value: Json;
+          updated_at?: string | null;
+          updated_by?: string | null;
+        };
         Update: {
-          description?: string | null
-          id?: string
-          setting_key?: string
-          setting_value?: Json
-          updated_at?: string | null
-          updated_by?: string | null
-        }
+          description?: string | null;
+          id?: string;
+          setting_key?: string;
+          setting_value?: Json;
+          updated_at?: string | null;
+          updated_by?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_system_config_updated_by_fkey"
-            columns: ["updated_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_system_config_updated_by_fkey';
+            columns: ['updated_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_system_config_updated_by_fkey"
-            columns: ["updated_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_system_config_updated_by_fkey';
+            columns: ['updated_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_system_config_updated_by_fkey"
-            columns: ["updated_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_system_config_updated_by_fkey';
+            columns: ['updated_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_system_config_updated_by_fkey"
-            columns: ["updated_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_system_config_updated_by_fkey';
+            columns: ['updated_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_system_config_updated_by_fkey"
-            columns: ["updated_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_system_config_updated_by_fkey';
+            columns: ['updated_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_system_config_updated_by_fkey"
-            columns: ["updated_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_system_config_updated_by_fkey';
+            columns: ['updated_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       mfa_verification_attempts: {
         Row: {
-          attempt_code: string | null
-          created_at: string | null
-          failure_reason: string | null
-          id: string
-          ip_address: unknown | null
-          is_backup_code: boolean | null
-          method_id: string | null
-          method_type: Database["public"]["Enums"]["mfa_method_type"]
-          processing_time_ms: number | null
-          session_id: string | null
-          status: Database["public"]["Enums"]["mfa_verification_status"]
-          user_agent: string | null
-          user_id: string
-        }
+          attempt_code: string | null;
+          created_at: string | null;
+          failure_reason: string | null;
+          id: string;
+          ip_address: unknown | null;
+          is_backup_code: boolean | null;
+          method_id: string | null;
+          method_type: Database['public']['Enums']['mfa_method_type'];
+          processing_time_ms: number | null;
+          session_id: string | null;
+          status: Database['public']['Enums']['mfa_verification_status'];
+          user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          attempt_code?: string | null
-          created_at?: string | null
-          failure_reason?: string | null
-          id?: string
-          ip_address?: unknown | null
-          is_backup_code?: boolean | null
-          method_id?: string | null
-          method_type: Database["public"]["Enums"]["mfa_method_type"]
-          processing_time_ms?: number | null
-          session_id?: string | null
-          status: Database["public"]["Enums"]["mfa_verification_status"]
-          user_agent?: string | null
-          user_id: string
-        }
+          attempt_code?: string | null;
+          created_at?: string | null;
+          failure_reason?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          is_backup_code?: boolean | null;
+          method_id?: string | null;
+          method_type: Database['public']['Enums']['mfa_method_type'];
+          processing_time_ms?: number | null;
+          session_id?: string | null;
+          status: Database['public']['Enums']['mfa_verification_status'];
+          user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          attempt_code?: string | null
-          created_at?: string | null
-          failure_reason?: string | null
-          id?: string
-          ip_address?: unknown | null
-          is_backup_code?: boolean | null
-          method_id?: string | null
-          method_type?: Database["public"]["Enums"]["mfa_method_type"]
-          processing_time_ms?: number | null
-          session_id?: string | null
-          status?: Database["public"]["Enums"]["mfa_verification_status"]
-          user_agent?: string | null
-          user_id?: string
-        }
+          attempt_code?: string | null;
+          created_at?: string | null;
+          failure_reason?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          is_backup_code?: boolean | null;
+          method_id?: string | null;
+          method_type?: Database['public']['Enums']['mfa_method_type'];
+          processing_time_ms?: number | null;
+          session_id?: string | null;
+          status?: Database['public']['Enums']['mfa_verification_status'];
+          user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mfa_verification_attempts_method_id_fkey"
-            columns: ["method_id"]
-            isOneToOne: false
-            referencedRelation: "user_mfa_methods"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_verification_attempts_method_id_fkey';
+            columns: ['method_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_mfa_methods';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "mfa_verification_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_verification_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_verification_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'mfa_verification_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "mfa_verification_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_verification_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_verification_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'mfa_verification_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "mfa_verification_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'mfa_verification_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "mfa_verification_attempts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mfa_verification_attempts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       notification_delivery_logs: {
         Row: {
-          channel: string
-          clicked_at: string | null
-          created_at: string | null
-          delivered_at: string | null
-          error_code: string | null
-          error_message: string | null
-          failed_at: string | null
-          id: string
-          notification_id: string
-          opened_at: string | null
-          provider_id: string | null
-          provider_response: Json | null
-          sent_at: string | null
-          status: string
-          updated_at: string | null
-        }
+          channel: string;
+          clicked_at: string | null;
+          created_at: string | null;
+          delivered_at: string | null;
+          error_code: string | null;
+          error_message: string | null;
+          failed_at: string | null;
+          id: string;
+          notification_id: string;
+          opened_at: string | null;
+          provider_id: string | null;
+          provider_response: Json | null;
+          sent_at: string | null;
+          status: string;
+          updated_at: string | null;
+        };
         Insert: {
-          channel: string
-          clicked_at?: string | null
-          created_at?: string | null
-          delivered_at?: string | null
-          error_code?: string | null
-          error_message?: string | null
-          failed_at?: string | null
-          id?: string
-          notification_id: string
-          opened_at?: string | null
-          provider_id?: string | null
-          provider_response?: Json | null
-          sent_at?: string | null
-          status?: string
-          updated_at?: string | null
-        }
+          channel: string;
+          clicked_at?: string | null;
+          created_at?: string | null;
+          delivered_at?: string | null;
+          error_code?: string | null;
+          error_message?: string | null;
+          failed_at?: string | null;
+          id?: string;
+          notification_id: string;
+          opened_at?: string | null;
+          provider_id?: string | null;
+          provider_response?: Json | null;
+          sent_at?: string | null;
+          status?: string;
+          updated_at?: string | null;
+        };
         Update: {
-          channel?: string
-          clicked_at?: string | null
-          created_at?: string | null
-          delivered_at?: string | null
-          error_code?: string | null
-          error_message?: string | null
-          failed_at?: string | null
-          id?: string
-          notification_id?: string
-          opened_at?: string | null
-          provider_id?: string | null
-          provider_response?: Json | null
-          sent_at?: string | null
-          status?: string
-          updated_at?: string | null
-        }
+          channel?: string;
+          clicked_at?: string | null;
+          created_at?: string | null;
+          delivered_at?: string | null;
+          error_code?: string | null;
+          error_message?: string | null;
+          failed_at?: string | null;
+          id?: string;
+          notification_id?: string;
+          opened_at?: string | null;
+          provider_id?: string | null;
+          provider_response?: Json | null;
+          sent_at?: string | null;
+          status?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "notification_delivery_logs_notification_id_fkey"
-            columns: ["notification_id"]
-            isOneToOne: false
-            referencedRelation: "notifications"
-            referencedColumns: ["id"]
+            foreignKeyName: 'notification_delivery_logs_notification_id_fkey';
+            columns: ['notification_id'];
+            isOneToOne: false;
+            referencedRelation: 'notifications';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       notification_jobs: {
         Row: {
-          completed_at: string | null
-          created_at: string | null
-          error_message: string | null
-          id: string
-          max_retries: number | null
-          payload: Json
-          priority: number | null
-          retry_count: number | null
-          scheduled_for: string
-          started_at: string | null
-          status: string
-          type: string
-          updated_at: string | null
-        }
+          completed_at: string | null;
+          created_at: string | null;
+          error_message: string | null;
+          id: string;
+          max_retries: number | null;
+          payload: Json;
+          priority: number | null;
+          retry_count: number | null;
+          scheduled_for: string;
+          started_at: string | null;
+          status: string;
+          type: string;
+          updated_at: string | null;
+        };
         Insert: {
-          completed_at?: string | null
-          created_at?: string | null
-          error_message?: string | null
-          id?: string
-          max_retries?: number | null
-          payload: Json
-          priority?: number | null
-          retry_count?: number | null
-          scheduled_for?: string
-          started_at?: string | null
-          status?: string
-          type: string
-          updated_at?: string | null
-        }
+          completed_at?: string | null;
+          created_at?: string | null;
+          error_message?: string | null;
+          id?: string;
+          max_retries?: number | null;
+          payload: Json;
+          priority?: number | null;
+          retry_count?: number | null;
+          scheduled_for?: string;
+          started_at?: string | null;
+          status?: string;
+          type: string;
+          updated_at?: string | null;
+        };
         Update: {
-          completed_at?: string | null
-          created_at?: string | null
-          error_message?: string | null
-          id?: string
-          max_retries?: number | null
-          payload?: Json
-          priority?: number | null
-          retry_count?: number | null
-          scheduled_for?: string
-          started_at?: string | null
-          status?: string
-          type?: string
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
+          completed_at?: string | null;
+          created_at?: string | null;
+          error_message?: string | null;
+          id?: string;
+          max_retries?: number | null;
+          payload?: Json;
+          priority?: number | null;
+          retry_count?: number | null;
+          scheduled_for?: string;
+          started_at?: string | null;
+          status?: string;
+          type?: string;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       notification_preferences: {
         Row: {
-          created_at: string | null
-          digest_frequency: string | null
-          email_enabled: boolean
-          email_marketing: boolean
-          email_messages: boolean
-          email_session_reminders: boolean
-          email_session_updates: boolean
-          email_system_updates: boolean
-          id: string
-          inapp_enabled: boolean
-          inapp_messages: boolean
-          inapp_session_reminders: boolean
-          inapp_session_updates: boolean
-          inapp_system_updates: boolean
-          push_enabled: boolean
-          push_messages: boolean
-          push_session_reminders: boolean
-          quiet_hours_enabled: boolean
-          quiet_hours_end: string | null
-          quiet_hours_start: string | null
-          timezone: string | null
-          updated_at: string | null
-          user_id: string
-        }
+          created_at: string | null;
+          digest_frequency: string | null;
+          email_enabled: boolean;
+          email_marketing: boolean;
+          email_messages: boolean;
+          email_session_reminders: boolean;
+          email_session_updates: boolean;
+          email_system_updates: boolean;
+          id: string;
+          inapp_enabled: boolean;
+          inapp_messages: boolean;
+          inapp_session_reminders: boolean;
+          inapp_session_updates: boolean;
+          inapp_system_updates: boolean;
+          push_enabled: boolean;
+          push_messages: boolean;
+          push_session_reminders: boolean;
+          quiet_hours_enabled: boolean;
+          quiet_hours_end: string | null;
+          quiet_hours_start: string | null;
+          timezone: string | null;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          digest_frequency?: string | null
-          email_enabled?: boolean
-          email_marketing?: boolean
-          email_messages?: boolean
-          email_session_reminders?: boolean
-          email_session_updates?: boolean
-          email_system_updates?: boolean
-          id?: string
-          inapp_enabled?: boolean
-          inapp_messages?: boolean
-          inapp_session_reminders?: boolean
-          inapp_session_updates?: boolean
-          inapp_system_updates?: boolean
-          push_enabled?: boolean
-          push_messages?: boolean
-          push_session_reminders?: boolean
-          quiet_hours_enabled?: boolean
-          quiet_hours_end?: string | null
-          quiet_hours_start?: string | null
-          timezone?: string | null
-          updated_at?: string | null
-          user_id: string
-        }
+          created_at?: string | null;
+          digest_frequency?: string | null;
+          email_enabled?: boolean;
+          email_marketing?: boolean;
+          email_messages?: boolean;
+          email_session_reminders?: boolean;
+          email_session_updates?: boolean;
+          email_system_updates?: boolean;
+          id?: string;
+          inapp_enabled?: boolean;
+          inapp_messages?: boolean;
+          inapp_session_reminders?: boolean;
+          inapp_session_updates?: boolean;
+          inapp_system_updates?: boolean;
+          push_enabled?: boolean;
+          push_messages?: boolean;
+          push_session_reminders?: boolean;
+          quiet_hours_enabled?: boolean;
+          quiet_hours_end?: string | null;
+          quiet_hours_start?: string | null;
+          timezone?: string | null;
+          updated_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          created_at?: string | null
-          digest_frequency?: string | null
-          email_enabled?: boolean
-          email_marketing?: boolean
-          email_messages?: boolean
-          email_session_reminders?: boolean
-          email_session_updates?: boolean
-          email_system_updates?: boolean
-          id?: string
-          inapp_enabled?: boolean
-          inapp_messages?: boolean
-          inapp_session_reminders?: boolean
-          inapp_session_updates?: boolean
-          inapp_system_updates?: boolean
-          push_enabled?: boolean
-          push_messages?: boolean
-          push_session_reminders?: boolean
-          quiet_hours_enabled?: boolean
-          quiet_hours_end?: string | null
-          quiet_hours_start?: string | null
-          timezone?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          digest_frequency?: string | null;
+          email_enabled?: boolean;
+          email_marketing?: boolean;
+          email_messages?: boolean;
+          email_session_reminders?: boolean;
+          email_session_updates?: boolean;
+          email_system_updates?: boolean;
+          id?: string;
+          inapp_enabled?: boolean;
+          inapp_messages?: boolean;
+          inapp_session_reminders?: boolean;
+          inapp_session_updates?: boolean;
+          inapp_system_updates?: boolean;
+          push_enabled?: boolean;
+          push_messages?: boolean;
+          push_session_reminders?: boolean;
+          quiet_hours_enabled?: boolean;
+          quiet_hours_end?: string | null;
+          quiet_hours_start?: string | null;
+          timezone?: string | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "notification_preferences_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'notification_preferences_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "notification_preferences_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'notification_preferences_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "notification_preferences_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'notification_preferences_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "notification_preferences_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'notification_preferences_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "notification_preferences_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'notification_preferences_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "notification_preferences_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'notification_preferences_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       notification_templates: {
         Row: {
-          body: string
-          channel: string
-          created_at: string | null
-          html_body: string | null
-          id: string
-          is_active: boolean
-          language: Database["public"]["Enums"]["language"]
-          subject: string | null
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          updated_at: string | null
-          variables: Json | null
-          version: number
-        }
+          body: string;
+          channel: string;
+          created_at: string | null;
+          html_body: string | null;
+          id: string;
+          is_active: boolean;
+          language: Database['public']['Enums']['language'];
+          subject: string | null;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          updated_at: string | null;
+          variables: Json | null;
+          version: number;
+        };
         Insert: {
-          body: string
-          channel: string
-          created_at?: string | null
-          html_body?: string | null
-          id?: string
-          is_active?: boolean
-          language?: Database["public"]["Enums"]["language"]
-          subject?: string | null
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          updated_at?: string | null
-          variables?: Json | null
-          version?: number
-        }
+          body: string;
+          channel: string;
+          created_at?: string | null;
+          html_body?: string | null;
+          id?: string;
+          is_active?: boolean;
+          language?: Database['public']['Enums']['language'];
+          subject?: string | null;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          updated_at?: string | null;
+          variables?: Json | null;
+          version?: number;
+        };
         Update: {
-          body?: string
-          channel?: string
-          created_at?: string | null
-          html_body?: string | null
-          id?: string
-          is_active?: boolean
-          language?: Database["public"]["Enums"]["language"]
-          subject?: string | null
-          title?: string
-          type?: Database["public"]["Enums"]["notification_type"]
-          updated_at?: string | null
-          variables?: Json | null
-          version?: number
-        }
-        Relationships: []
-      }
+          body?: string;
+          channel?: string;
+          created_at?: string | null;
+          html_body?: string | null;
+          id?: string;
+          is_active?: boolean;
+          language?: Database['public']['Enums']['language'];
+          subject?: string | null;
+          title?: string;
+          type?: Database['public']['Enums']['notification_type'];
+          updated_at?: string | null;
+          variables?: Json | null;
+          version?: number;
+        };
+        Relationships: [];
+      };
       notifications: {
         Row: {
-          action_label: string | null
-          action_url: string | null
-          channel: string | null
-          created_at: string | null
-          data: Json | null
-          expires_at: string | null
-          id: string
-          message: string
-          priority: string | null
-          read_at: string | null
-          scheduled_for: string | null
-          sent_at: string | null
-          template_id: string | null
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          user_id: string
-        }
+          action_label: string | null;
+          action_url: string | null;
+          channel: string | null;
+          created_at: string | null;
+          data: Json | null;
+          expires_at: string | null;
+          id: string;
+          message: string;
+          priority: string | null;
+          read_at: string | null;
+          scheduled_for: string | null;
+          sent_at: string | null;
+          template_id: string | null;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          user_id: string;
+        };
         Insert: {
-          action_label?: string | null
-          action_url?: string | null
-          channel?: string | null
-          created_at?: string | null
-          data?: Json | null
-          expires_at?: string | null
-          id?: string
-          message: string
-          priority?: string | null
-          read_at?: string | null
-          scheduled_for?: string | null
-          sent_at?: string | null
-          template_id?: string | null
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          user_id: string
-        }
+          action_label?: string | null;
+          action_url?: string | null;
+          channel?: string | null;
+          created_at?: string | null;
+          data?: Json | null;
+          expires_at?: string | null;
+          id?: string;
+          message: string;
+          priority?: string | null;
+          read_at?: string | null;
+          scheduled_for?: string | null;
+          sent_at?: string | null;
+          template_id?: string | null;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          user_id: string;
+        };
         Update: {
-          action_label?: string | null
-          action_url?: string | null
-          channel?: string | null
-          created_at?: string | null
-          data?: Json | null
-          expires_at?: string | null
-          id?: string
-          message?: string
-          priority?: string | null
-          read_at?: string | null
-          scheduled_for?: string | null
-          sent_at?: string | null
-          template_id?: string | null
-          title?: string
-          type?: Database["public"]["Enums"]["notification_type"]
-          user_id?: string
-        }
+          action_label?: string | null;
+          action_url?: string | null;
+          channel?: string | null;
+          created_at?: string | null;
+          data?: Json | null;
+          expires_at?: string | null;
+          id?: string;
+          message?: string;
+          priority?: string | null;
+          read_at?: string | null;
+          scheduled_for?: string | null;
+          sent_at?: string | null;
+          template_id?: string | null;
+          title?: string;
+          type?: Database['public']['Enums']['notification_type'];
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "notifications_template_id_fkey"
-            columns: ["template_id"]
-            isOneToOne: false
-            referencedRelation: "notification_templates"
-            referencedColumns: ["id"]
+            foreignKeyName: 'notifications_template_id_fkey';
+            columns: ['template_id'];
+            isOneToOne: false;
+            referencedRelation: 'notification_templates';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       payments: {
         Row: {
-          amount_cents: number
-          created_at: string
-          currency: string
-          description: string | null
-          id: string
-          idempotency_key: string | null
-          metadata: Json | null
-          provider: string
-          provider_transaction_id: string | null
-          raw_payload: Json | null
-          status: string
-          updated_at: string
-          user_id: string | null
-        }
+          amount_cents: number;
+          created_at: string;
+          currency: string;
+          description: string | null;
+          id: string;
+          idempotency_key: string | null;
+          metadata: Json | null;
+          provider: string;
+          provider_transaction_id: string | null;
+          raw_payload: Json | null;
+          status: string;
+          updated_at: string;
+          user_id: string | null;
+        };
         Insert: {
-          amount_cents: number
-          created_at?: string
-          currency?: string
-          description?: string | null
-          id?: string
-          idempotency_key?: string | null
-          metadata?: Json | null
-          provider?: string
-          provider_transaction_id?: string | null
-          raw_payload?: Json | null
-          status?: string
-          updated_at?: string
-          user_id?: string | null
-        }
+          amount_cents: number;
+          created_at?: string;
+          currency?: string;
+          description?: string | null;
+          id?: string;
+          idempotency_key?: string | null;
+          metadata?: Json | null;
+          provider?: string;
+          provider_transaction_id?: string | null;
+          raw_payload?: Json | null;
+          status?: string;
+          updated_at?: string;
+          user_id?: string | null;
+        };
         Update: {
-          amount_cents?: number
-          created_at?: string
-          currency?: string
-          description?: string | null
-          id?: string
-          idempotency_key?: string | null
-          metadata?: Json | null
-          provider?: string
-          provider_transaction_id?: string | null
-          raw_payload?: Json | null
-          status?: string
-          updated_at?: string
-          user_id?: string | null
-        }
+          amount_cents?: number;
+          created_at?: string;
+          currency?: string;
+          description?: string | null;
+          id?: string;
+          idempotency_key?: string | null;
+          metadata?: Json | null;
+          provider?: string;
+          provider_transaction_id?: string | null;
+          raw_payload?: Json | null;
+          status?: string;
+          updated_at?: string;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "payments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'payments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "payments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'payments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "payments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'payments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "payments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'payments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "payments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'payments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "payments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'payments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       practice_journal_entries: {
         Row: {
-          body_areas: string[] | null
-          client_id: string
-          content: string
-          created_at: string | null
-          emotions: string[] | null
-          energy_level: number | null
-          id: string
-          insights: string | null
-          mood_rating: number | null
-          practices_done: string[] | null
-          sensations: string[] | null
-          session_id: string | null
-          shared_at: string | null
-          shared_with_coach: boolean | null
-          title: string | null
-          updated_at: string | null
-        }
+          body_areas: string[] | null;
+          client_id: string;
+          content: string;
+          created_at: string | null;
+          emotions: string[] | null;
+          energy_level: number | null;
+          id: string;
+          insights: string | null;
+          mood_rating: number | null;
+          practices_done: string[] | null;
+          sensations: string[] | null;
+          session_id: string | null;
+          shared_at: string | null;
+          shared_with_coach: boolean | null;
+          title: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          body_areas?: string[] | null
-          client_id: string
-          content: string
-          created_at?: string | null
-          emotions?: string[] | null
-          energy_level?: number | null
-          id?: string
-          insights?: string | null
-          mood_rating?: number | null
-          practices_done?: string[] | null
-          sensations?: string[] | null
-          session_id?: string | null
-          shared_at?: string | null
-          shared_with_coach?: boolean | null
-          title?: string | null
-          updated_at?: string | null
-        }
+          body_areas?: string[] | null;
+          client_id: string;
+          content: string;
+          created_at?: string | null;
+          emotions?: string[] | null;
+          energy_level?: number | null;
+          id?: string;
+          insights?: string | null;
+          mood_rating?: number | null;
+          practices_done?: string[] | null;
+          sensations?: string[] | null;
+          session_id?: string | null;
+          shared_at?: string | null;
+          shared_with_coach?: boolean | null;
+          title?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          body_areas?: string[] | null
-          client_id?: string
-          content?: string
-          created_at?: string | null
-          emotions?: string[] | null
-          energy_level?: number | null
-          id?: string
-          insights?: string | null
-          mood_rating?: number | null
-          practices_done?: string[] | null
-          sensations?: string[] | null
-          session_id?: string | null
-          shared_at?: string | null
-          shared_with_coach?: boolean | null
-          title?: string | null
-          updated_at?: string | null
-        }
+          body_areas?: string[] | null;
+          client_id?: string;
+          content?: string;
+          created_at?: string | null;
+          emotions?: string[] | null;
+          energy_level?: number | null;
+          id?: string;
+          insights?: string | null;
+          mood_rating?: number | null;
+          practices_done?: string[] | null;
+          sensations?: string[] | null;
+          session_id?: string | null;
+          shared_at?: string | null;
+          shared_with_coach?: boolean | null;
+          title?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "practice_journal_entries_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'practice_journal_entries_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'practice_journal_entries_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'practice_journal_entries_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'practice_journal_entries_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'practice_journal_entries_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'practice_journal_entries_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'practice_journal_entries_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "practice_journal_entries_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'practice_journal_entries_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       push_subscriptions: {
         Row: {
-          auth_key: string
-          created_at: string | null
-          endpoint: string
-          id: string
-          is_active: boolean
-          p256dh_key: string
-          updated_at: string | null
-          user_agent: string | null
-          user_id: string
-        }
+          auth_key: string;
+          created_at: string | null;
+          endpoint: string;
+          id: string;
+          is_active: boolean;
+          p256dh_key: string;
+          updated_at: string | null;
+          user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          auth_key: string
-          created_at?: string | null
-          endpoint: string
-          id?: string
-          is_active?: boolean
-          p256dh_key: string
-          updated_at?: string | null
-          user_agent?: string | null
-          user_id: string
-        }
+          auth_key: string;
+          created_at?: string | null;
+          endpoint: string;
+          id?: string;
+          is_active?: boolean;
+          p256dh_key: string;
+          updated_at?: string | null;
+          user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          auth_key?: string
-          created_at?: string | null
-          endpoint?: string
-          id?: string
-          is_active?: boolean
-          p256dh_key?: string
-          updated_at?: string | null
-          user_agent?: string | null
-          user_id?: string
-        }
+          auth_key?: string;
+          created_at?: string | null;
+          endpoint?: string;
+          id?: string;
+          is_active?: boolean;
+          p256dh_key?: string;
+          updated_at?: string | null;
+          user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "push_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'push_subscriptions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "push_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'push_subscriptions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "push_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'push_subscriptions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "push_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'push_subscriptions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "push_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'push_subscriptions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "push_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'push_subscriptions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       quarantined_files: {
         Row: {
-          auto_delete_at: string | null
-          file_hash: string
-          file_size: number
-          file_type: string | null
-          id: string
-          original_file_name: string
-          quarantine_reason: string
-          quarantined_at: string | null
-          review_notes: string | null
-          review_status: string | null
-          reviewed_at: string | null
-          reviewed_by: string | null
-          scan_details: string | null
-          scan_provider: string
-          threat_name: string
-          upload_ip_address: unknown | null
-          uploaded_by: string | null
-        }
+          auto_delete_at: string | null;
+          file_hash: string;
+          file_size: number;
+          file_type: string | null;
+          id: string;
+          original_file_name: string;
+          quarantine_reason: string;
+          quarantined_at: string | null;
+          review_notes: string | null;
+          review_status: string | null;
+          reviewed_at: string | null;
+          reviewed_by: string | null;
+          scan_details: string | null;
+          scan_provider: string;
+          threat_name: string;
+          upload_ip_address: unknown | null;
+          uploaded_by: string | null;
+        };
         Insert: {
-          auto_delete_at?: string | null
-          file_hash: string
-          file_size: number
-          file_type?: string | null
-          id?: string
-          original_file_name: string
-          quarantine_reason: string
-          quarantined_at?: string | null
-          review_notes?: string | null
-          review_status?: string | null
-          reviewed_at?: string | null
-          reviewed_by?: string | null
-          scan_details?: string | null
-          scan_provider: string
-          threat_name: string
-          upload_ip_address?: unknown | null
-          uploaded_by?: string | null
-        }
+          auto_delete_at?: string | null;
+          file_hash: string;
+          file_size: number;
+          file_type?: string | null;
+          id?: string;
+          original_file_name: string;
+          quarantine_reason: string;
+          quarantined_at?: string | null;
+          review_notes?: string | null;
+          review_status?: string | null;
+          reviewed_at?: string | null;
+          reviewed_by?: string | null;
+          scan_details?: string | null;
+          scan_provider: string;
+          threat_name: string;
+          upload_ip_address?: unknown | null;
+          uploaded_by?: string | null;
+        };
         Update: {
-          auto_delete_at?: string | null
-          file_hash?: string
-          file_size?: number
-          file_type?: string | null
-          id?: string
-          original_file_name?: string
-          quarantine_reason?: string
-          quarantined_at?: string | null
-          review_notes?: string | null
-          review_status?: string | null
-          reviewed_at?: string | null
-          reviewed_by?: string | null
-          scan_details?: string | null
-          scan_provider?: string
-          threat_name?: string
-          upload_ip_address?: unknown | null
-          uploaded_by?: string | null
-        }
+          auto_delete_at?: string | null;
+          file_hash?: string;
+          file_size?: number;
+          file_type?: string | null;
+          id?: string;
+          original_file_name?: string;
+          quarantine_reason?: string;
+          quarantined_at?: string | null;
+          review_notes?: string | null;
+          review_status?: string | null;
+          reviewed_at?: string | null;
+          reviewed_by?: string | null;
+          scan_details?: string | null;
+          scan_provider?: string;
+          threat_name?: string;
+          upload_ip_address?: unknown | null;
+          uploaded_by?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "quarantined_files_reviewed_by_fkey"
-            columns: ["reviewed_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'quarantined_files_reviewed_by_fkey';
+            columns: ['reviewed_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "quarantined_files_reviewed_by_fkey"
-            columns: ["reviewed_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'quarantined_files_reviewed_by_fkey';
+            columns: ['reviewed_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "quarantined_files_reviewed_by_fkey"
-            columns: ["reviewed_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'quarantined_files_reviewed_by_fkey';
+            columns: ['reviewed_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "quarantined_files_reviewed_by_fkey"
-            columns: ["reviewed_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'quarantined_files_reviewed_by_fkey';
+            columns: ['reviewed_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "quarantined_files_reviewed_by_fkey"
-            columns: ["reviewed_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'quarantined_files_reviewed_by_fkey';
+            columns: ['reviewed_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "quarantined_files_reviewed_by_fkey"
-            columns: ["reviewed_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'quarantined_files_reviewed_by_fkey';
+            columns: ['reviewed_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "quarantined_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'quarantined_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "quarantined_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'quarantined_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "quarantined_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'quarantined_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "quarantined_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'quarantined_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "quarantined_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'quarantined_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "quarantined_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'quarantined_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       rate_limit_violations: {
         Row: {
-          endpoint: string
-          id: string
-          ip_address: unknown
-          limit_exceeded_at: string | null
-          request_count: number
-          user_agent: string | null
-          user_id: string | null
-          window_end: string
-          window_start: string
-        }
+          endpoint: string;
+          id: string;
+          ip_address: unknown;
+          limit_exceeded_at: string | null;
+          request_count: number;
+          user_agent: string | null;
+          user_id: string | null;
+          window_end: string;
+          window_start: string;
+        };
         Insert: {
-          endpoint: string
-          id?: string
-          ip_address: unknown
-          limit_exceeded_at?: string | null
-          request_count: number
-          user_agent?: string | null
-          user_id?: string | null
-          window_end: string
-          window_start: string
-        }
+          endpoint: string;
+          id?: string;
+          ip_address: unknown;
+          limit_exceeded_at?: string | null;
+          request_count: number;
+          user_agent?: string | null;
+          user_id?: string | null;
+          window_end: string;
+          window_start: string;
+        };
         Update: {
-          endpoint?: string
-          id?: string
-          ip_address?: unknown
-          limit_exceeded_at?: string | null
-          request_count?: number
-          user_agent?: string | null
-          user_id?: string | null
-          window_end?: string
-          window_start?: string
-        }
+          endpoint?: string;
+          id?: string;
+          ip_address?: unknown;
+          limit_exceeded_at?: string | null;
+          request_count?: number;
+          user_agent?: string | null;
+          user_id?: string | null;
+          window_end?: string;
+          window_start?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "rate_limit_violations_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'rate_limit_violations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "rate_limit_violations_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'rate_limit_violations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "rate_limit_violations_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'rate_limit_violations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "rate_limit_violations_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'rate_limit_violations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "rate_limit_violations_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'rate_limit_violations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "rate_limit_violations_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'rate_limit_violations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       reflections: {
         Row: {
-          client_id: string
-          content: string
-          created_at: string | null
-          goals_for_next_session: string | null
-          id: string
-          insights: string | null
-          mood_rating: number | null
-          session_id: string | null
-          updated_at: string | null
-        }
+          client_id: string;
+          content: string;
+          created_at: string | null;
+          goals_for_next_session: string | null;
+          id: string;
+          insights: string | null;
+          mood_rating: number | null;
+          session_id: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          client_id: string
-          content: string
-          created_at?: string | null
-          goals_for_next_session?: string | null
-          id?: string
-          insights?: string | null
-          mood_rating?: number | null
-          session_id?: string | null
-          updated_at?: string | null
-        }
+          client_id: string;
+          content: string;
+          created_at?: string | null;
+          goals_for_next_session?: string | null;
+          id?: string;
+          insights?: string | null;
+          mood_rating?: number | null;
+          session_id?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          client_id?: string
-          content?: string
-          created_at?: string | null
-          goals_for_next_session?: string | null
-          id?: string
-          insights?: string | null
-          mood_rating?: number | null
-          session_id?: string | null
-          updated_at?: string | null
-        }
+          client_id?: string;
+          content?: string;
+          created_at?: string | null;
+          goals_for_next_session?: string | null;
+          id?: string;
+          insights?: string | null;
+          mood_rating?: number | null;
+          session_id?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "reflections_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'reflections_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "reflections_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'reflections_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "reflections_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'reflections_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "reflections_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'reflections_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "reflections_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'reflections_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "reflections_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'reflections_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "reflections_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'reflections_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "reflections_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'reflections_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       scheduled_notifications: {
         Row: {
-          channel: string
-          created_at: string | null
-          error_message: string | null
-          id: string
-          max_retries: number | null
-          message: string
-          priority: string
-          retry_count: number | null
-          scheduled_for: string
-          sent_at: string | null
-          status: string
-          template_id: string | null
-          template_variables: Json | null
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          updated_at: string | null
-          user_id: string
-        }
+          channel: string;
+          created_at: string | null;
+          error_message: string | null;
+          id: string;
+          max_retries: number | null;
+          message: string;
+          priority: string;
+          retry_count: number | null;
+          scheduled_for: string;
+          sent_at: string | null;
+          status: string;
+          template_id: string | null;
+          template_variables: Json | null;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          channel: string
-          created_at?: string | null
-          error_message?: string | null
-          id?: string
-          max_retries?: number | null
-          message: string
-          priority?: string
-          retry_count?: number | null
-          scheduled_for: string
-          sent_at?: string | null
-          status?: string
-          template_id?: string | null
-          template_variables?: Json | null
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          updated_at?: string | null
-          user_id: string
-        }
+          channel: string;
+          created_at?: string | null;
+          error_message?: string | null;
+          id?: string;
+          max_retries?: number | null;
+          message: string;
+          priority?: string;
+          retry_count?: number | null;
+          scheduled_for: string;
+          sent_at?: string | null;
+          status?: string;
+          template_id?: string | null;
+          template_variables?: Json | null;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          updated_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          channel?: string
-          created_at?: string | null
-          error_message?: string | null
-          id?: string
-          max_retries?: number | null
-          message?: string
-          priority?: string
-          retry_count?: number | null
-          scheduled_for?: string
-          sent_at?: string | null
-          status?: string
-          template_id?: string | null
-          template_variables?: Json | null
-          title?: string
-          type?: Database["public"]["Enums"]["notification_type"]
-          updated_at?: string | null
-          user_id?: string
-        }
+          channel?: string;
+          created_at?: string | null;
+          error_message?: string | null;
+          id?: string;
+          max_retries?: number | null;
+          message?: string;
+          priority?: string;
+          retry_count?: number | null;
+          scheduled_for?: string;
+          sent_at?: string | null;
+          status?: string;
+          template_id?: string | null;
+          template_variables?: Json | null;
+          title?: string;
+          type?: Database['public']['Enums']['notification_type'];
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "scheduled_notifications_template_id_fkey"
-            columns: ["template_id"]
-            isOneToOne: false
-            referencedRelation: "notification_templates"
-            referencedColumns: ["id"]
+            foreignKeyName: 'scheduled_notifications_template_id_fkey';
+            columns: ['template_id'];
+            isOneToOne: false;
+            referencedRelation: 'notification_templates';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "scheduled_notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'scheduled_notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "scheduled_notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'scheduled_notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "scheduled_notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'scheduled_notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "scheduled_notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'scheduled_notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "scheduled_notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'scheduled_notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "scheduled_notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'scheduled_notifications_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       security_audit_log: {
         Row: {
-          event_details: Json | null
-          event_type: string
-          id: string
-          ip_address: unknown | null
-          severity: string | null
-          timestamp: string | null
-          user_agent: string | null
-          user_id: string | null
-        }
+          event_details: Json | null;
+          event_type: string;
+          id: string;
+          ip_address: unknown | null;
+          severity: string | null;
+          timestamp: string | null;
+          user_agent: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          event_details?: Json | null
-          event_type: string
-          id?: string
-          ip_address?: unknown | null
-          severity?: string | null
-          timestamp?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          event_details?: Json | null;
+          event_type: string;
+          id?: string;
+          ip_address?: unknown | null;
+          severity?: string | null;
+          timestamp?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          event_details?: Json | null
-          event_type?: string
-          id?: string
-          ip_address?: unknown | null
-          severity?: string | null
-          timestamp?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          event_details?: Json | null;
+          event_type?: string;
+          id?: string;
+          ip_address?: unknown | null;
+          severity?: string | null;
+          timestamp?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "security_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'security_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "security_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'security_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "security_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'security_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "security_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'security_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "security_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'security_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "security_audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'security_audit_log_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       security_logs: {
         Row: {
-          activity_type: string
-          details: string | null
-          id: string
-          ip_address: unknown
-          referer: string | null
-          request_method: string | null
-          request_path: string | null
-          resolution_notes: string | null
-          resolved_at: string | null
-          resolved_by: string | null
-          severity: Database["public"]["Enums"]["security_severity"]
-          timestamp: string | null
-          user_agent: string | null
-          user_id: string | null
-        }
+          activity_type: string;
+          details: string | null;
+          id: string;
+          ip_address: unknown;
+          referer: string | null;
+          request_method: string | null;
+          request_path: string | null;
+          resolution_notes: string | null;
+          resolved_at: string | null;
+          resolved_by: string | null;
+          severity: Database['public']['Enums']['security_severity'];
+          timestamp: string | null;
+          user_agent: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          activity_type: string
-          details?: string | null
-          id?: string
-          ip_address: unknown
-          referer?: string | null
-          request_method?: string | null
-          request_path?: string | null
-          resolution_notes?: string | null
-          resolved_at?: string | null
-          resolved_by?: string | null
-          severity?: Database["public"]["Enums"]["security_severity"]
-          timestamp?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          activity_type: string;
+          details?: string | null;
+          id?: string;
+          ip_address: unknown;
+          referer?: string | null;
+          request_method?: string | null;
+          request_path?: string | null;
+          resolution_notes?: string | null;
+          resolved_at?: string | null;
+          resolved_by?: string | null;
+          severity?: Database['public']['Enums']['security_severity'];
+          timestamp?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          activity_type?: string
-          details?: string | null
-          id?: string
-          ip_address?: unknown
-          referer?: string | null
-          request_method?: string | null
-          request_path?: string | null
-          resolution_notes?: string | null
-          resolved_at?: string | null
-          resolved_by?: string | null
-          severity?: Database["public"]["Enums"]["security_severity"]
-          timestamp?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          activity_type?: string;
+          details?: string | null;
+          id?: string;
+          ip_address?: unknown;
+          referer?: string | null;
+          request_method?: string | null;
+          request_path?: string | null;
+          resolution_notes?: string | null;
+          resolved_at?: string | null;
+          resolved_by?: string | null;
+          severity?: Database['public']['Enums']['security_severity'];
+          timestamp?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "security_logs_resolved_by_fkey"
-            columns: ["resolved_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'security_logs_resolved_by_fkey';
+            columns: ['resolved_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "security_logs_resolved_by_fkey"
-            columns: ["resolved_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'security_logs_resolved_by_fkey';
+            columns: ['resolved_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "security_logs_resolved_by_fkey"
-            columns: ["resolved_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'security_logs_resolved_by_fkey';
+            columns: ['resolved_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "security_logs_resolved_by_fkey"
-            columns: ["resolved_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'security_logs_resolved_by_fkey';
+            columns: ['resolved_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "security_logs_resolved_by_fkey"
-            columns: ["resolved_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'security_logs_resolved_by_fkey';
+            columns: ['resolved_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "security_logs_resolved_by_fkey"
-            columns: ["resolved_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'security_logs_resolved_by_fkey';
+            columns: ['resolved_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "security_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'security_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "security_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'security_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "security_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'security_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "security_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'security_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "security_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'security_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "security_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'security_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       session_feedback: {
         Row: {
-          anonymous: boolean
-          client_id: string
-          coach_id: string
-          communication_rating: number | null
-          created_at: string | null
-          feedback_text: string | null
-          helpfulness_rating: number | null
-          id: string
-          overall_rating: number
-          preparation_rating: number | null
-          session_id: string
-          updated_at: string | null
-          would_recommend: boolean | null
-        }
+          anonymous: boolean;
+          client_id: string;
+          coach_id: string;
+          communication_rating: number | null;
+          created_at: string | null;
+          feedback_text: string | null;
+          helpfulness_rating: number | null;
+          id: string;
+          overall_rating: number;
+          preparation_rating: number | null;
+          session_id: string;
+          updated_at: string | null;
+          would_recommend: boolean | null;
+        };
         Insert: {
-          anonymous?: boolean
-          client_id: string
-          coach_id: string
-          communication_rating?: number | null
-          created_at?: string | null
-          feedback_text?: string | null
-          helpfulness_rating?: number | null
-          id?: string
-          overall_rating: number
-          preparation_rating?: number | null
-          session_id: string
-          updated_at?: string | null
-          would_recommend?: boolean | null
-        }
+          anonymous?: boolean;
+          client_id: string;
+          coach_id: string;
+          communication_rating?: number | null;
+          created_at?: string | null;
+          feedback_text?: string | null;
+          helpfulness_rating?: number | null;
+          id?: string;
+          overall_rating: number;
+          preparation_rating?: number | null;
+          session_id: string;
+          updated_at?: string | null;
+          would_recommend?: boolean | null;
+        };
         Update: {
-          anonymous?: boolean
-          client_id?: string
-          coach_id?: string
-          communication_rating?: number | null
-          created_at?: string | null
-          feedback_text?: string | null
-          helpfulness_rating?: number | null
-          id?: string
-          overall_rating?: number
-          preparation_rating?: number | null
-          session_id?: string
-          updated_at?: string | null
-          would_recommend?: boolean | null
-        }
+          anonymous?: boolean;
+          client_id?: string;
+          coach_id?: string;
+          communication_rating?: number | null;
+          created_at?: string | null;
+          feedback_text?: string | null;
+          helpfulness_rating?: number | null;
+          id?: string;
+          overall_rating?: number;
+          preparation_rating?: number | null;
+          session_id?: string;
+          updated_at?: string | null;
+          would_recommend?: boolean | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "session_feedback_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_feedback_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_feedback_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_feedback_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_feedback_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_feedback_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_feedback_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_feedback_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_feedback_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'session_feedback_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "session_feedback_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_feedback_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_feedback_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_feedback_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_feedback_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_feedback_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_feedback_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_feedback_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_feedback_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_feedback_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_feedback_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'session_feedback_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "session_feedback_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_feedback_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_feedback_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_feedback_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_feedback_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_feedback_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       session_files: {
         Row: {
-          created_at: string | null
-          file_category: Database["public"]["Enums"]["file_category"]
-          file_id: string
-          id: string
-          is_required: boolean
-          session_id: string
-          uploaded_by: string | null
-        }
+          created_at: string | null;
+          file_category: Database['public']['Enums']['file_category'];
+          file_id: string;
+          id: string;
+          is_required: boolean;
+          session_id: string;
+          uploaded_by: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          file_category?: Database["public"]["Enums"]["file_category"]
-          file_id: string
-          id?: string
-          is_required?: boolean
-          session_id: string
-          uploaded_by?: string | null
-        }
+          created_at?: string | null;
+          file_category?: Database['public']['Enums']['file_category'];
+          file_id: string;
+          id?: string;
+          is_required?: boolean;
+          session_id: string;
+          uploaded_by?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          file_category?: Database["public"]["Enums"]["file_category"]
-          file_id?: string
-          id?: string
-          is_required?: boolean
-          session_id?: string
-          uploaded_by?: string | null
-        }
+          created_at?: string | null;
+          file_category?: Database['public']['Enums']['file_category'];
+          file_id?: string;
+          id?: string;
+          is_required?: boolean;
+          session_id?: string;
+          uploaded_by?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "session_files_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_files_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_files_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_files_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_files_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_files_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_files_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_files_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'session_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "session_files_uploaded_by_fkey"
-            columns: ["uploaded_by"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_files_uploaded_by_fkey';
+            columns: ['uploaded_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       session_ratings: {
         Row: {
-          client_id: string
-          coach_id: string
-          created_at: string | null
-          id: string
-          rating: number
-          review: string | null
-          session_id: string
-          updated_at: string | null
-        }
+          client_id: string;
+          coach_id: string;
+          created_at: string | null;
+          id: string;
+          rating: number;
+          review: string | null;
+          session_id: string;
+          updated_at: string | null;
+        };
         Insert: {
-          client_id: string
-          coach_id: string
-          created_at?: string | null
-          id?: string
-          rating: number
-          review?: string | null
-          session_id: string
-          updated_at?: string | null
-        }
+          client_id: string;
+          coach_id: string;
+          created_at?: string | null;
+          id?: string;
+          rating: number;
+          review?: string | null;
+          session_id: string;
+          updated_at?: string | null;
+        };
         Update: {
-          client_id?: string
-          coach_id?: string
-          created_at?: string | null
-          id?: string
-          rating?: number
-          review?: string | null
-          session_id?: string
-          updated_at?: string | null
-        }
+          client_id?: string;
+          coach_id?: string;
+          created_at?: string | null;
+          id?: string;
+          rating?: number;
+          review?: string | null;
+          session_id?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "session_ratings_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_ratings_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_ratings_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_ratings_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_ratings_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_ratings_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_ratings_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_ratings_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_ratings_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'session_ratings_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "session_ratings_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_ratings_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_ratings_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_ratings_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_ratings_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'session_ratings_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "session_ratings_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_ratings_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_ratings_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'session_ratings_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "session_ratings_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'session_ratings_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "session_ratings_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_ratings_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_ratings_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: true
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_ratings_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: true;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "session_ratings_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: true
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'session_ratings_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: true;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       sessions: {
         Row: {
-          client_id: string
-          coach_id: string
-          created_at: string | null
-          description: string | null
-          duration_minutes: number
-          id: string
-          meeting_url: string | null
-          notes: string | null
-          scheduled_at: string
-          status: Database["public"]["Enums"]["session_status"]
-          title: string
-          type: string
-          updated_at: string | null
-        }
+          client_id: string;
+          coach_id: string;
+          created_at: string | null;
+          description: string | null;
+          duration_minutes: number;
+          id: string;
+          meeting_url: string | null;
+          notes: string | null;
+          scheduled_at: string;
+          status: Database['public']['Enums']['session_status'];
+          title: string;
+          type: string;
+          updated_at: string | null;
+        };
         Insert: {
-          client_id: string
-          coach_id: string
-          created_at?: string | null
-          description?: string | null
-          duration_minutes?: number
-          id?: string
-          meeting_url?: string | null
-          notes?: string | null
-          scheduled_at: string
-          status?: Database["public"]["Enums"]["session_status"]
-          title: string
-          type?: string
-          updated_at?: string | null
-        }
+          client_id: string;
+          coach_id: string;
+          created_at?: string | null;
+          description?: string | null;
+          duration_minutes?: number;
+          id?: string;
+          meeting_url?: string | null;
+          notes?: string | null;
+          scheduled_at: string;
+          status?: Database['public']['Enums']['session_status'];
+          title: string;
+          type?: string;
+          updated_at?: string | null;
+        };
         Update: {
-          client_id?: string
-          coach_id?: string
-          created_at?: string | null
-          description?: string | null
-          duration_minutes?: number
-          id?: string
-          meeting_url?: string | null
-          notes?: string | null
-          scheduled_at?: string
-          status?: Database["public"]["Enums"]["session_status"]
-          title?: string
-          type?: string
-          updated_at?: string | null
-        }
+          client_id?: string;
+          coach_id?: string;
+          created_at?: string | null;
+          description?: string | null;
+          duration_minutes?: number;
+          id?: string;
+          meeting_url?: string | null;
+          notes?: string | null;
+          scheduled_at?: string;
+          status?: Database['public']['Enums']['session_status'];
+          title?: string;
+          type?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "sessions_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'sessions_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "sessions_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'sessions_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "sessions_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'sessions_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "sessions_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'sessions_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "sessions_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'sessions_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "sessions_client_id_fkey"
-            columns: ["client_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'sessions_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "sessions_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'sessions_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "sessions_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'sessions_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "sessions_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'sessions_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "sessions_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'sessions_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "sessions_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'sessions_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "sessions_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'sessions_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       system_audit_logs: {
         Row: {
-          action: Database["public"]["Enums"]["audit_action_type"]
-          created_at: string
-          description: string | null
-          id: string
-          ip_address: unknown | null
-          metadata: Json | null
-          request_id: string | null
-          resource: string | null
-          resource_id: string | null
-          risk_level: string | null
-          session_id: string | null
-          user_agent: string | null
-          user_email: string | null
-          user_id: string | null
-        }
+          action: Database['public']['Enums']['audit_action_type'];
+          created_at: string;
+          description: string | null;
+          id: string;
+          ip_address: unknown | null;
+          metadata: Json | null;
+          request_id: string | null;
+          resource: string | null;
+          resource_id: string | null;
+          risk_level: string | null;
+          session_id: string | null;
+          user_agent: string | null;
+          user_email: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          action: Database["public"]["Enums"]["audit_action_type"]
-          created_at?: string
-          description?: string | null
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          request_id?: string | null
-          resource?: string | null
-          resource_id?: string | null
-          risk_level?: string | null
-          session_id?: string | null
-          user_agent?: string | null
-          user_email?: string | null
-          user_id?: string | null
-        }
+          action: Database['public']['Enums']['audit_action_type'];
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          request_id?: string | null;
+          resource?: string | null;
+          resource_id?: string | null;
+          risk_level?: string | null;
+          session_id?: string | null;
+          user_agent?: string | null;
+          user_email?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          action?: Database["public"]["Enums"]["audit_action_type"]
-          created_at?: string
-          description?: string | null
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          request_id?: string | null
-          resource?: string | null
-          resource_id?: string | null
-          risk_level?: string | null
-          session_id?: string | null
-          user_agent?: string | null
-          user_email?: string | null
-          user_id?: string | null
-        }
-        Relationships: []
-      }
+          action?: Database['public']['Enums']['audit_action_type'];
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          request_id?: string | null;
+          resource?: string | null;
+          resource_id?: string | null;
+          risk_level?: string | null;
+          session_id?: string | null;
+          user_agent?: string | null;
+          user_email?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
       system_health: {
         Row: {
-          component: string
-          created_at: string | null
-          id: string
-          last_checked_at: string | null
-          metrics: Json | null
-          status: string
-        }
+          component: string;
+          created_at: string | null;
+          id: string;
+          last_checked_at: string | null;
+          metrics: Json | null;
+          status: string;
+        };
         Insert: {
-          component: string
-          created_at?: string | null
-          id?: string
-          last_checked_at?: string | null
-          metrics?: Json | null
-          status: string
-        }
+          component: string;
+          created_at?: string | null;
+          id?: string;
+          last_checked_at?: string | null;
+          metrics?: Json | null;
+          status: string;
+        };
         Update: {
-          component?: string
-          created_at?: string | null
-          id?: string
-          last_checked_at?: string | null
-          metrics?: Json | null
-          status?: string
-        }
-        Relationships: []
-      }
+          component?: string;
+          created_at?: string | null;
+          id?: string;
+          last_checked_at?: string | null;
+          metrics?: Json | null;
+          status?: string;
+        };
+        Relationships: [];
+      };
       system_health_checks: {
         Row: {
-          check_type: string
-          created_at: string
-          error_message: string | null
-          id: string
-          metrics: Json | null
-          performed_by: string | null
-          response_time_ms: number | null
-          status: string
-        }
+          check_type: string;
+          created_at: string;
+          error_message: string | null;
+          id: string;
+          metrics: Json | null;
+          performed_by: string | null;
+          response_time_ms: number | null;
+          status: string;
+        };
         Insert: {
-          check_type: string
-          created_at?: string
-          error_message?: string | null
-          id?: string
-          metrics?: Json | null
-          performed_by?: string | null
-          response_time_ms?: number | null
-          status: string
-        }
+          check_type: string;
+          created_at?: string;
+          error_message?: string | null;
+          id?: string;
+          metrics?: Json | null;
+          performed_by?: string | null;
+          response_time_ms?: number | null;
+          status: string;
+        };
         Update: {
-          check_type?: string
-          created_at?: string
-          error_message?: string | null
-          id?: string
-          metrics?: Json | null
-          performed_by?: string | null
-          response_time_ms?: number | null
-          status?: string
-        }
-        Relationships: []
-      }
+          check_type?: string;
+          created_at?: string;
+          error_message?: string | null;
+          id?: string;
+          metrics?: Json | null;
+          performed_by?: string | null;
+          response_time_ms?: number | null;
+          status?: string;
+        };
+        Relationships: [];
+      };
       temporary_file_shares: {
         Row: {
-          created_at: string | null
-          created_by: string
-          current_downloads: number | null
-          description: string | null
-          expires_at: string
-          file_id: string
-          id: string
-          is_active: boolean | null
-          max_downloads: number | null
-          metadata: Json | null
-          password_hash: string | null
-          share_token: string
-          updated_at: string | null
-        }
+          created_at: string | null;
+          created_by: string;
+          current_downloads: number | null;
+          description: string | null;
+          expires_at: string;
+          file_id: string;
+          id: string;
+          is_active: boolean | null;
+          max_downloads: number | null;
+          metadata: Json | null;
+          password_hash: string | null;
+          share_token: string;
+          updated_at: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          created_by: string
-          current_downloads?: number | null
-          description?: string | null
-          expires_at: string
-          file_id: string
-          id?: string
-          is_active?: boolean | null
-          max_downloads?: number | null
-          metadata?: Json | null
-          password_hash?: string | null
-          share_token: string
-          updated_at?: string | null
-        }
+          created_at?: string | null;
+          created_by: string;
+          current_downloads?: number | null;
+          description?: string | null;
+          expires_at: string;
+          file_id: string;
+          id?: string;
+          is_active?: boolean | null;
+          max_downloads?: number | null;
+          metadata?: Json | null;
+          password_hash?: string | null;
+          share_token: string;
+          updated_at?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          created_by?: string
-          current_downloads?: number | null
-          description?: string | null
-          expires_at?: string
-          file_id?: string
-          id?: string
-          is_active?: boolean | null
-          max_downloads?: number | null
-          metadata?: Json | null
-          password_hash?: string | null
-          share_token?: string
-          updated_at?: string | null
-        }
+          created_at?: string | null;
+          created_by?: string;
+          current_downloads?: number | null;
+          description?: string | null;
+          expires_at?: string;
+          file_id?: string;
+          id?: string;
+          is_active?: boolean | null;
+          max_downloads?: number | null;
+          metadata?: Json | null;
+          password_hash?: string | null;
+          share_token?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "temporary_file_shares_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'temporary_file_shares_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "temporary_file_shares_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'temporary_file_shares_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       temporary_share_access_logs: {
         Row: {
-          access_type: string
-          accessed_at: string | null
-          bytes_served: number | null
-          city: string | null
-          country_code: string | null
-          failure_reason: string | null
-          id: string
-          ip_address: unknown | null
-          metadata: Json | null
-          share_id: string
-          success: boolean
-          user_agent: string | null
-        }
+          access_type: string;
+          accessed_at: string | null;
+          bytes_served: number | null;
+          city: string | null;
+          country_code: string | null;
+          failure_reason: string | null;
+          id: string;
+          ip_address: unknown | null;
+          metadata: Json | null;
+          share_id: string;
+          success: boolean;
+          user_agent: string | null;
+        };
         Insert: {
-          access_type?: string
-          accessed_at?: string | null
-          bytes_served?: number | null
-          city?: string | null
-          country_code?: string | null
-          failure_reason?: string | null
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          share_id: string
-          success?: boolean
-          user_agent?: string | null
-        }
+          access_type?: string;
+          accessed_at?: string | null;
+          bytes_served?: number | null;
+          city?: string | null;
+          country_code?: string | null;
+          failure_reason?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          share_id: string;
+          success?: boolean;
+          user_agent?: string | null;
+        };
         Update: {
-          access_type?: string
-          accessed_at?: string | null
-          bytes_served?: number | null
-          city?: string | null
-          country_code?: string | null
-          failure_reason?: string | null
-          id?: string
-          ip_address?: unknown | null
-          metadata?: Json | null
-          share_id?: string
-          success?: boolean
-          user_agent?: string | null
-        }
+          access_type?: string;
+          accessed_at?: string | null;
+          bytes_served?: number | null;
+          city?: string | null;
+          country_code?: string | null;
+          failure_reason?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          metadata?: Json | null;
+          share_id?: string;
+          success?: boolean;
+          user_agent?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "temporary_share_access_logs_share_id_fkey"
-            columns: ["share_id"]
-            isOneToOne: false
-            referencedRelation: "temporary_file_shares"
-            referencedColumns: ["id"]
+            foreignKeyName: 'temporary_share_access_logs_share_id_fkey';
+            columns: ['share_id'];
+            isOneToOne: false;
+            referencedRelation: 'temporary_file_shares';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       trusted_devices: {
         Row: {
-          created_at: string | null
-          created_from_ip: unknown | null
-          device_fingerprint: string
-          device_name: string | null
-          expires_at: string
-          id: string
-          ip_address: unknown | null
-          last_used_at: string | null
-          user_agent: string | null
-          user_id: string
-        }
+          created_at: string | null;
+          created_from_ip: unknown | null;
+          device_fingerprint: string;
+          device_name: string | null;
+          expires_at: string;
+          id: string;
+          ip_address: unknown | null;
+          last_used_at: string | null;
+          user_agent: string | null;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          created_from_ip?: unknown | null
-          device_fingerprint: string
-          device_name?: string | null
-          expires_at: string
-          id?: string
-          ip_address?: unknown | null
-          last_used_at?: string | null
-          user_agent?: string | null
-          user_id: string
-        }
+          created_at?: string | null;
+          created_from_ip?: unknown | null;
+          device_fingerprint: string;
+          device_name?: string | null;
+          expires_at: string;
+          id?: string;
+          ip_address?: unknown | null;
+          last_used_at?: string | null;
+          user_agent?: string | null;
+          user_id: string;
+        };
         Update: {
-          created_at?: string | null
-          created_from_ip?: unknown | null
-          device_fingerprint?: string
-          device_name?: string | null
-          expires_at?: string
-          id?: string
-          ip_address?: unknown | null
-          last_used_at?: string | null
-          user_agent?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          created_from_ip?: unknown | null;
+          device_fingerprint?: string;
+          device_name?: string | null;
+          expires_at?: string;
+          id?: string;
+          ip_address?: unknown | null;
+          last_used_at?: string | null;
+          user_agent?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "trusted_devices_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'trusted_devices_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "trusted_devices_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'trusted_devices_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "trusted_devices_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'trusted_devices_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "trusted_devices_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'trusted_devices_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "trusted_devices_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'trusted_devices_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "trusted_devices_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'trusted_devices_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       typing_indicators: {
         Row: {
-          conversation_id: string
-          expires_at: string | null
-          id: string
-          started_at: string | null
-          user_id: string
-        }
+          conversation_id: string;
+          expires_at: string | null;
+          id: string;
+          started_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          conversation_id: string
-          expires_at?: string | null
-          id?: string
-          started_at?: string | null
-          user_id: string
-        }
+          conversation_id: string;
+          expires_at?: string | null;
+          id?: string;
+          started_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          conversation_id?: string
-          expires_at?: string | null
-          id?: string
-          started_at?: string | null
-          user_id?: string
-        }
+          conversation_id?: string;
+          expires_at?: string | null;
+          id?: string;
+          started_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "typing_indicators_conversation_id_fkey"
-            columns: ["conversation_id"]
-            isOneToOne: false
-            referencedRelation: "conversations"
-            referencedColumns: ["id"]
+            foreignKeyName: 'typing_indicators_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "typing_indicators_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "typing_indicators_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "typing_indicators_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "typing_indicators_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "typing_indicators_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "typing_indicators_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       user_download_statistics: {
         Row: {
-          created_at: string | null
-          favorite_download_method: string | null
-          file_id: string
-          first_download_at: string | null
-          id: string
-          last_download_at: string | null
-          metadata: Json | null
-          total_bandwidth_used: number | null
-          total_downloads: number | null
-          updated_at: string | null
-          user_id: string
-        }
+          created_at: string | null;
+          favorite_download_method: string | null;
+          file_id: string;
+          first_download_at: string | null;
+          id: string;
+          last_download_at: string | null;
+          metadata: Json | null;
+          total_bandwidth_used: number | null;
+          total_downloads: number | null;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          favorite_download_method?: string | null
-          file_id: string
-          first_download_at?: string | null
-          id?: string
-          last_download_at?: string | null
-          metadata?: Json | null
-          total_bandwidth_used?: number | null
-          total_downloads?: number | null
-          updated_at?: string | null
-          user_id: string
-        }
+          created_at?: string | null;
+          favorite_download_method?: string | null;
+          file_id: string;
+          first_download_at?: string | null;
+          id?: string;
+          last_download_at?: string | null;
+          metadata?: Json | null;
+          total_bandwidth_used?: number | null;
+          total_downloads?: number | null;
+          updated_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          created_at?: string | null
-          favorite_download_method?: string | null
-          file_id?: string
-          first_download_at?: string | null
-          id?: string
-          last_download_at?: string | null
-          metadata?: Json | null
-          total_bandwidth_used?: number | null
-          total_downloads?: number | null
-          updated_at?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          favorite_download_method?: string | null;
+          file_id?: string;
+          first_download_at?: string | null;
+          id?: string;
+          last_download_at?: string | null;
+          metadata?: Json | null;
+          total_bandwidth_used?: number | null;
+          total_downloads?: number | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_download_statistics_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "file_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 'user_download_statistics_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'file_uploads';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "user_download_statistics_file_id_fkey"
-            columns: ["file_id"]
-            isOneToOne: false
-            referencedRelation: "user_accessible_files"
-            referencedColumns: ["id"]
+            foreignKeyName: 'user_download_statistics_file_id_fkey';
+            columns: ['file_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_accessible_files';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       user_mfa: {
         Row: {
-          backup_codes: string[] | null
-          created_at: string | null
-          id: string
-          is_enabled: boolean
-          secret_key: string | null
-          updated_at: string | null
-          user_id: string
-          verified_at: string | null
-        }
+          backup_codes: string[] | null;
+          created_at: string | null;
+          id: string;
+          is_enabled: boolean;
+          secret_key: string | null;
+          updated_at: string | null;
+          user_id: string;
+          verified_at: string | null;
+        };
         Insert: {
-          backup_codes?: string[] | null
-          created_at?: string | null
-          id?: string
-          is_enabled?: boolean
-          secret_key?: string | null
-          updated_at?: string | null
-          user_id: string
-          verified_at?: string | null
-        }
+          backup_codes?: string[] | null;
+          created_at?: string | null;
+          id?: string;
+          is_enabled?: boolean;
+          secret_key?: string | null;
+          updated_at?: string | null;
+          user_id: string;
+          verified_at?: string | null;
+        };
         Update: {
-          backup_codes?: string[] | null
-          created_at?: string | null
-          id?: string
-          is_enabled?: boolean
-          secret_key?: string | null
-          updated_at?: string | null
-          user_id?: string
-          verified_at?: string | null
-        }
+          backup_codes?: string[] | null;
+          created_at?: string | null;
+          id?: string;
+          is_enabled?: boolean;
+          secret_key?: string | null;
+          updated_at?: string | null;
+          user_id?: string;
+          verified_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_mfa_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'user_mfa_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "user_mfa_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'user_mfa_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "user_mfa_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'user_mfa_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "user_mfa_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'user_mfa_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "user_mfa_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'user_mfa_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "user_mfa_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'user_mfa_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       user_mfa_methods: {
         Row: {
-          created_at: string | null
-          credential_id: string | null
-          email_address: string | null
-          failure_count: number | null
-          id: string
-          last_used_at: string | null
-          locked_until: string | null
-          method_name: string | null
-          method_type: Database["public"]["Enums"]["mfa_method_type"]
-          phone_number: string | null
-          public_key: string | null
-          qr_code_url: string | null
-          secret_encrypted: string | null
-          secret_salt: string | null
-          status: Database["public"]["Enums"]["mfa_status"]
-          updated_at: string | null
-          user_id: string
-          verification_code: string | null
-          verification_expires_at: string | null
-        }
+          created_at: string | null;
+          credential_id: string | null;
+          email_address: string | null;
+          failure_count: number | null;
+          id: string;
+          last_used_at: string | null;
+          locked_until: string | null;
+          method_name: string | null;
+          method_type: Database['public']['Enums']['mfa_method_type'];
+          phone_number: string | null;
+          public_key: string | null;
+          qr_code_url: string | null;
+          secret_encrypted: string | null;
+          secret_salt: string | null;
+          status: Database['public']['Enums']['mfa_status'];
+          updated_at: string | null;
+          user_id: string;
+          verification_code: string | null;
+          verification_expires_at: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          credential_id?: string | null
-          email_address?: string | null
-          failure_count?: number | null
-          id?: string
-          last_used_at?: string | null
-          locked_until?: string | null
-          method_name?: string | null
-          method_type: Database["public"]["Enums"]["mfa_method_type"]
-          phone_number?: string | null
-          public_key?: string | null
-          qr_code_url?: string | null
-          secret_encrypted?: string | null
-          secret_salt?: string | null
-          status?: Database["public"]["Enums"]["mfa_status"]
-          updated_at?: string | null
-          user_id: string
-          verification_code?: string | null
-          verification_expires_at?: string | null
-        }
+          created_at?: string | null;
+          credential_id?: string | null;
+          email_address?: string | null;
+          failure_count?: number | null;
+          id?: string;
+          last_used_at?: string | null;
+          locked_until?: string | null;
+          method_name?: string | null;
+          method_type: Database['public']['Enums']['mfa_method_type'];
+          phone_number?: string | null;
+          public_key?: string | null;
+          qr_code_url?: string | null;
+          secret_encrypted?: string | null;
+          secret_salt?: string | null;
+          status?: Database['public']['Enums']['mfa_status'];
+          updated_at?: string | null;
+          user_id: string;
+          verification_code?: string | null;
+          verification_expires_at?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          credential_id?: string | null
-          email_address?: string | null
-          failure_count?: number | null
-          id?: string
-          last_used_at?: string | null
-          locked_until?: string | null
-          method_name?: string | null
-          method_type?: Database["public"]["Enums"]["mfa_method_type"]
-          phone_number?: string | null
-          public_key?: string | null
-          qr_code_url?: string | null
-          secret_encrypted?: string | null
-          secret_salt?: string | null
-          status?: Database["public"]["Enums"]["mfa_status"]
-          updated_at?: string | null
-          user_id?: string
-          verification_code?: string | null
-          verification_expires_at?: string | null
-        }
+          created_at?: string | null;
+          credential_id?: string | null;
+          email_address?: string | null;
+          failure_count?: number | null;
+          id?: string;
+          last_used_at?: string | null;
+          locked_until?: string | null;
+          method_name?: string | null;
+          method_type?: Database['public']['Enums']['mfa_method_type'];
+          phone_number?: string | null;
+          public_key?: string | null;
+          qr_code_url?: string | null;
+          secret_encrypted?: string | null;
+          secret_salt?: string | null;
+          status?: Database['public']['Enums']['mfa_status'];
+          updated_at?: string | null;
+          user_id?: string;
+          verification_code?: string | null;
+          verification_expires_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_mfa_methods_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'user_mfa_methods_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "user_mfa_methods_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'user_mfa_methods_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "user_mfa_methods_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'user_mfa_methods_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "user_mfa_methods_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'user_mfa_methods_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "user_mfa_methods_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'user_mfa_methods_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "user_mfa_methods_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'user_mfa_methods_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       user_mfa_settings: {
         Row: {
-          backup_codes_generated: boolean
-          created_at: string | null
-          id: string
-          is_enabled: boolean
-          is_enforced: boolean
-          last_backup_codes_generated_at: string | null
-          recovery_email: string | null
-          updated_at: string | null
-          user_id: string
-        }
+          backup_codes_generated: boolean;
+          created_at: string | null;
+          id: string;
+          is_enabled: boolean;
+          is_enforced: boolean;
+          last_backup_codes_generated_at: string | null;
+          recovery_email: string | null;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          backup_codes_generated?: boolean
-          created_at?: string | null
-          id?: string
-          is_enabled?: boolean
-          is_enforced?: boolean
-          last_backup_codes_generated_at?: string | null
-          recovery_email?: string | null
-          updated_at?: string | null
-          user_id: string
-        }
+          backup_codes_generated?: boolean;
+          created_at?: string | null;
+          id?: string;
+          is_enabled?: boolean;
+          is_enforced?: boolean;
+          last_backup_codes_generated_at?: string | null;
+          recovery_email?: string | null;
+          updated_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          backup_codes_generated?: boolean
-          created_at?: string | null
-          id?: string
-          is_enabled?: boolean
-          is_enforced?: boolean
-          last_backup_codes_generated_at?: string | null
-          recovery_email?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
+          backup_codes_generated?: boolean;
+          created_at?: string | null;
+          id?: string;
+          is_enabled?: boolean;
+          is_enforced?: boolean;
+          last_backup_codes_generated_at?: string | null;
+          recovery_email?: string | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_mfa_settings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'user_mfa_settings_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "user_mfa_settings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'user_mfa_settings_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "user_mfa_settings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'user_mfa_settings_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "user_mfa_settings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'user_mfa_settings_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "user_mfa_settings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'user_mfa_settings_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "user_mfa_settings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'user_mfa_settings_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       users: {
         Row: {
-          avatar_url: string | null
-          created_at: string | null
-          email: string
-          first_name: string | null
-          id: string
-          language: Database["public"]["Enums"]["language"]
-          last_name: string | null
-          last_seen_at: string | null
-          mfa_backup_codes: string[] | null
-          mfa_enabled: boolean | null
-          mfa_secret: string | null
-          mfa_setup_completed: boolean | null
-          mfa_verified_at: string | null
-          phone: string | null
-          remember_device_enabled: boolean | null
-          role: Database["public"]["Enums"]["user_role"]
-          status: Database["public"]["Enums"]["user_status"]
-          timezone: string | null
-          updated_at: string | null
-        }
+          avatar_url: string | null;
+          created_at: string | null;
+          email: string;
+          first_name: string | null;
+          id: string;
+          language: Database['public']['Enums']['language'];
+          last_name: string | null;
+          last_seen_at: string | null;
+          mfa_backup_codes: string[] | null;
+          mfa_enabled: boolean | null;
+          mfa_secret: string | null;
+          mfa_setup_completed: boolean | null;
+          mfa_verified_at: string | null;
+          phone: string | null;
+          remember_device_enabled: boolean | null;
+          role: Database['public']['Enums']['user_role'];
+          status: Database['public']['Enums']['user_status'];
+          timezone: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          avatar_url?: string | null
-          created_at?: string | null
-          email: string
-          first_name?: string | null
-          id: string
-          language?: Database["public"]["Enums"]["language"]
-          last_name?: string | null
-          last_seen_at?: string | null
-          mfa_backup_codes?: string[] | null
-          mfa_enabled?: boolean | null
-          mfa_secret?: string | null
-          mfa_setup_completed?: boolean | null
-          mfa_verified_at?: string | null
-          phone?: string | null
-          remember_device_enabled?: boolean | null
-          role?: Database["public"]["Enums"]["user_role"]
-          status?: Database["public"]["Enums"]["user_status"]
-          timezone?: string | null
-          updated_at?: string | null
-        }
+          avatar_url?: string | null;
+          created_at?: string | null;
+          email: string;
+          first_name?: string | null;
+          id: string;
+          language?: Database['public']['Enums']['language'];
+          last_name?: string | null;
+          last_seen_at?: string | null;
+          mfa_backup_codes?: string[] | null;
+          mfa_enabled?: boolean | null;
+          mfa_secret?: string | null;
+          mfa_setup_completed?: boolean | null;
+          mfa_verified_at?: string | null;
+          phone?: string | null;
+          remember_device_enabled?: boolean | null;
+          role?: Database['public']['Enums']['user_role'];
+          status?: Database['public']['Enums']['user_status'];
+          timezone?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          avatar_url?: string | null
-          created_at?: string | null
-          email?: string
-          first_name?: string | null
-          id?: string
-          language?: Database["public"]["Enums"]["language"]
-          last_name?: string | null
-          last_seen_at?: string | null
-          mfa_backup_codes?: string[] | null
-          mfa_enabled?: boolean | null
-          mfa_secret?: string | null
-          mfa_setup_completed?: boolean | null
-          mfa_verified_at?: string | null
-          phone?: string | null
-          remember_device_enabled?: boolean | null
-          role?: Database["public"]["Enums"]["user_role"]
-          status?: Database["public"]["Enums"]["user_status"]
-          timezone?: string | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
+          avatar_url?: string | null;
+          created_at?: string | null;
+          email?: string;
+          first_name?: string | null;
+          id?: string;
+          language?: Database['public']['Enums']['language'];
+          last_name?: string | null;
+          last_seen_at?: string | null;
+          mfa_backup_codes?: string[] | null;
+          mfa_enabled?: boolean | null;
+          mfa_secret?: string | null;
+          mfa_setup_completed?: boolean | null;
+          mfa_verified_at?: string | null;
+          phone?: string | null;
+          remember_device_enabled?: boolean | null;
+          role?: Database['public']['Enums']['user_role'];
+          status?: Database['public']['Enums']['user_status'];
+          timezone?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       virus_scan_cache: {
         Row: {
-          created_at: string | null
-          expires_at: string
-          file_hash: string
-          id: string
-          is_safe: boolean
-          scan_details: string | null
-          scan_id: string | null
-          scan_provider: string
-          threat_name: string | null
-        }
+          created_at: string | null;
+          expires_at: string;
+          file_hash: string;
+          id: string;
+          is_safe: boolean;
+          scan_details: string | null;
+          scan_id: string | null;
+          scan_provider: string;
+          threat_name: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          expires_at: string
-          file_hash: string
-          id?: string
-          is_safe: boolean
-          scan_details?: string | null
-          scan_id?: string | null
-          scan_provider?: string
-          threat_name?: string | null
-        }
+          created_at?: string | null;
+          expires_at: string;
+          file_hash: string;
+          id?: string;
+          is_safe: boolean;
+          scan_details?: string | null;
+          scan_id?: string | null;
+          scan_provider?: string;
+          threat_name?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          expires_at?: string
-          file_hash?: string
-          id?: string
-          is_safe?: boolean
-          scan_details?: string | null
-          scan_id?: string | null
-          scan_provider?: string
-          threat_name?: string | null
-        }
-        Relationships: []
-      }
+          created_at?: string | null;
+          expires_at?: string;
+          file_hash?: string;
+          id?: string;
+          is_safe?: boolean;
+          scan_details?: string | null;
+          scan_id?: string | null;
+          scan_provider?: string;
+          threat_name?: string | null;
+        };
+        Relationships: [];
+      };
       virus_scan_logs: {
         Row: {
-          created_at: string | null
-          file_hash: string
-          file_name: string
-          file_size: number
-          file_type: string | null
-          id: string
-          ip_address: unknown | null
-          is_safe: boolean
-          quarantined: boolean | null
-          scan_details: string | null
-          scan_duration_ms: number | null
-          scan_provider: string
-          threat_name: string | null
-          user_agent: string | null
-          user_id: string | null
-        }
+          created_at: string | null;
+          file_hash: string;
+          file_name: string;
+          file_size: number;
+          file_type: string | null;
+          id: string;
+          ip_address: unknown | null;
+          is_safe: boolean;
+          quarantined: boolean | null;
+          scan_details: string | null;
+          scan_duration_ms: number | null;
+          scan_provider: string;
+          threat_name: string | null;
+          user_agent: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          file_hash: string
-          file_name: string
-          file_size: number
-          file_type?: string | null
-          id?: string
-          ip_address?: unknown | null
-          is_safe: boolean
-          quarantined?: boolean | null
-          scan_details?: string | null
-          scan_duration_ms?: number | null
-          scan_provider?: string
-          threat_name?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          created_at?: string | null;
+          file_hash: string;
+          file_name: string;
+          file_size: number;
+          file_type?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          is_safe: boolean;
+          quarantined?: boolean | null;
+          scan_details?: string | null;
+          scan_duration_ms?: number | null;
+          scan_provider?: string;
+          threat_name?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          file_hash?: string
-          file_name?: string
-          file_size?: number
-          file_type?: string | null
-          id?: string
-          ip_address?: unknown | null
-          is_safe?: boolean
-          quarantined?: boolean | null
-          scan_details?: string | null
-          scan_duration_ms?: number | null
-          scan_provider?: string
-          threat_name?: string | null
-          user_agent?: string | null
-          user_id?: string | null
-        }
+          created_at?: string | null;
+          file_hash?: string;
+          file_name?: string;
+          file_size?: number;
+          file_type?: string | null;
+          id?: string;
+          ip_address?: unknown | null;
+          is_safe?: boolean;
+          quarantined?: boolean | null;
+          scan_details?: string | null;
+          scan_duration_ms?: number | null;
+          scan_provider?: string;
+          threat_name?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "virus_scan_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'virus_scan_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "virus_scan_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'virus_scan_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "virus_scan_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'virus_scan_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "virus_scan_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'virus_scan_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "virus_scan_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'virus_scan_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "virus_scan_logs_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'virus_scan_logs_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+      task_attachments: {
+        Row: {
+          created_at: string;
+          file_name: string;
+          file_size: number;
+          file_url: string;
+          id: string;
+          mime_type: string | null;
+          progress_update_id: string | null;
+          task_instance_id: string | null;
+          uploaded_by_id: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          file_name: string;
+          file_size: number;
+          file_url: string;
+          id?: string;
+          mime_type?: string | null;
+          progress_update_id?: string | null;
+          task_instance_id?: string | null;
+          uploaded_by_id?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          file_name?: string;
+          file_size?: number;
+          file_url?: string;
+          id?: string;
+          mime_type?: string | null;
+          progress_update_id?: string | null;
+          task_instance_id?: string | null;
+          uploaded_by_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'task_attachments_task_instance_id_fkey';
+            columns: ['task_instance_id'];
+            isOneToOne: false;
+            referencedRelation: 'task_instances';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'task_attachments_progress_update_id_fkey';
+            columns: ['progress_update_id'];
+            isOneToOne: false;
+            referencedRelation: 'task_progress_updates';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'task_attachments_uploaded_by_id_fkey';
+            columns: ['uploaded_by_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      task_categories: {
+        Row: {
+          coach_id: string;
+          color_hex: string | null;
+          created_at: string;
+          id: string;
+          label: string;
+          updated_at: string;
+        };
+        Insert: {
+          coach_id: string;
+          color_hex?: string | null;
+          created_at?: string;
+          id?: string;
+          label: string;
+          updated_at?: string;
+        };
+        Update: {
+          coach_id?: string;
+          color_hex?: string | null;
+          created_at?: string;
+          id?: string;
+          label?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'task_categories_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      task_export_logs: {
+        Row: {
+          client_id: string;
+          coach_id: string;
+          file_url: string;
+          filters: Json;
+          generated_at: string;
+          id: string;
+        };
+        Insert: {
+          client_id: string;
+          coach_id: string;
+          file_url: string;
+          filters?: Json;
+          generated_at?: string;
+          id?: string;
+        };
+        Update: {
+          client_id?: string;
+          coach_id?: string;
+          file_url?: string;
+          filters?: Json;
+          generated_at?: string;
+          id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'task_export_logs_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'task_export_logs_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      task_instances: {
+        Row: {
+          completed_at: string | null;
+          completion_percentage: number;
+          created_at: string;
+          due_date: string;
+          id: string;
+          scheduled_date: string | null;
+          status: Database['public']['Enums']['task_status'];
+          task_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          completed_at?: string | null;
+          completion_percentage?: number;
+          created_at?: string;
+          due_date: string;
+          id?: string;
+          scheduled_date?: string | null;
+          status?: Database['public']['Enums']['task_status'];
+          task_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          completed_at?: string | null;
+          completion_percentage?: number;
+          created_at?: string;
+          due_date?: string;
+          id?: string;
+          scheduled_date?: string | null;
+          status?: Database['public']['Enums']['task_status'];
+          task_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'task_instances_task_id_fkey';
+            columns: ['task_id'];
+            isOneToOne: false;
+            referencedRelation: 'tasks';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      task_notification_jobs: {
+        Row: {
+          created_at: string;
+          id: string;
+          payload: Json;
+          scheduled_at: string;
+          sent_at: string | null;
+          status: Database['public']['Enums']['task_notification_status'];
+          task_instance_id: string;
+          type: Database['public']['Enums']['task_notification_type'];
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          payload?: Json;
+          scheduled_at: string;
+          sent_at?: string | null;
+          status?: Database['public']['Enums']['task_notification_status'];
+          task_instance_id: string;
+          type: Database['public']['Enums']['task_notification_type'];
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          payload?: Json;
+          scheduled_at?: string;
+          sent_at?: string | null;
+          status?: Database['public']['Enums']['task_notification_status'];
+          task_instance_id?: string;
+          type?: Database['public']['Enums']['task_notification_type'];
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'task_notification_jobs_task_instance_id_fkey';
+            columns: ['task_instance_id'];
+            isOneToOne: false;
+            referencedRelation: 'task_instances';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      task_progress_updates: {
+        Row: {
+          author_id: string;
+          created_at: string;
+          id: string;
+          is_visible_to_coach: boolean;
+          note: string | null;
+          percentage: number;
+          task_instance_id: string;
+        };
+        Insert: {
+          author_id: string;
+          created_at?: string;
+          id?: string;
+          is_visible_to_coach?: boolean;
+          note?: string | null;
+          percentage: number;
+          task_instance_id: string;
+        };
+        Update: {
+          author_id?: string;
+          created_at?: string;
+          id?: string;
+          is_visible_to_coach?: boolean;
+          note?: string | null;
+          percentage?: number;
+          task_instance_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'task_progress_updates_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'task_progress_updates_task_instance_id_fkey';
+            columns: ['task_instance_id'];
+            isOneToOne: false;
+            referencedRelation: 'task_instances';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      tasks: {
+        Row: {
+          archived_at: string | null;
+          category_id: string | null;
+          client_id: string;
+          coach_id: string;
+          created_at: string;
+          description: string | null;
+          due_date: string | null;
+          id: string;
+          priority: Database['public']['Enums']['task_priority'];
+          recurrence_rule: Json | null;
+          status: Database['public']['Enums']['task_status'];
+          title: string;
+          updated_at: string;
+          visibility_to_coach: boolean;
+        };
+        Insert: {
+          archived_at?: string | null;
+          category_id?: string | null;
+          client_id: string;
+          coach_id: string;
+          created_at?: string;
+          description?: string | null;
+          due_date?: string | null;
+          id?: string;
+          priority?: Database['public']['Enums']['task_priority'];
+          recurrence_rule?: Json | null;
+          status?: Database['public']['Enums']['task_status'];
+          title: string;
+          updated_at?: string;
+          visibility_to_coach?: boolean;
+        };
+        Update: {
+          archived_at?: string | null;
+          category_id?: string | null;
+          client_id?: string;
+          coach_id?: string;
+          created_at?: string;
+          description?: string | null;
+          due_date?: string | null;
+          id?: string;
+          priority?: Database['public']['Enums']['task_priority'];
+          recurrence_rule?: Json | null;
+          status?: Database['public']['Enums']['task_status'];
+          title?: string;
+          updated_at?: string;
+          visibility_to_coach?: boolean;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'tasks_category_id_fkey';
+            columns: ['category_id'];
+            isOneToOne: false;
+            referencedRelation: 'task_categories';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'tasks_client_id_fkey';
+            columns: ['client_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'tasks_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+    };
     Views: {
       client_progress: {
         Row: {
-          average_rating: number | null
-          client_id: string | null
-          client_name: string | null
-          client_since: string | null
-          completed_sessions: number | null
-          email: string | null
-          last_session_date: string | null
-          total_ratings: number | null
-          total_sessions: number | null
-          upcoming_sessions: number | null
-        }
-        Relationships: []
-      }
+          average_rating: number | null;
+          client_id: string | null;
+          client_name: string | null;
+          client_since: string | null;
+          completed_sessions: number | null;
+          email: string | null;
+          last_session_date: string | null;
+          total_ratings: number | null;
+          total_sessions: number | null;
+          upcoming_sessions: number | null;
+        };
+        Relationships: [];
+      };
       client_progress_summary: {
         Row: {
-          average_rating: number | null
-          client_id: string | null
-          client_name: string | null
-          completed_sessions: number | null
-          last_session_date: string | null
-          total_sessions: number | null
-          upcoming_sessions: number | null
-        }
-        Relationships: []
-      }
+          average_rating: number | null;
+          client_id: string | null;
+          client_name: string | null;
+          completed_sessions: number | null;
+          last_session_date: string | null;
+          total_sessions: number | null;
+          upcoming_sessions: number | null;
+        };
+        Relationships: [];
+      };
       coach_availability_with_timezone: {
         Row: {
-          coach_id: string | null
-          coach_name: string | null
-          created_at: string | null
-          day_of_week: number | null
-          end_time: string | null
-          id: string | null
-          is_available: boolean | null
-          start_time: string | null
-          timezone: string | null
-          updated_at: string | null
-        }
+          coach_id: string | null;
+          coach_name: string | null;
+          created_at: string | null;
+          day_of_week: number | null;
+          end_time: string | null;
+          id: string | null;
+          is_available: boolean | null;
+          start_time: string | null;
+          timezone: string | null;
+          updated_at: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "coach_availability_coach_id_fkey"
-            columns: ["coach_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'coach_availability_coach_id_fkey';
+            columns: ['coach_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       coach_statistics: {
         Row: {
-          average_rating: number | null
-          coach_id: string | null
-          coach_name: string | null
-          completed_sessions: number | null
-          email: string | null
-          last_session_date: string | null
-          total_clients: number | null
-          total_ratings: number | null
-          total_sessions: number | null
-          upcoming_sessions: number | null
-        }
-        Relationships: []
-      }
+          average_rating: number | null;
+          coach_id: string | null;
+          coach_name: string | null;
+          completed_sessions: number | null;
+          email: string | null;
+          last_session_date: string | null;
+          total_clients: number | null;
+          total_ratings: number | null;
+          total_sessions: number | null;
+          upcoming_sessions: number | null;
+        };
+        Relationships: [];
+      };
       coach_stats: {
         Row: {
-          active_clients: number | null
-          avg_rating: number | null
-          coach_id: string | null
-          completed_sessions: number | null
-          completion_rate: number | null
-          email: string | null
-          name: string | null
-          total_ratings: number | null
-          total_sessions: number | null
-        }
-        Relationships: []
-      }
+          active_clients: number | null;
+          avg_rating: number | null;
+          coach_id: string | null;
+          completed_sessions: number | null;
+          completion_rate: number | null;
+          email: string | null;
+          name: string | null;
+          total_ratings: number | null;
+          total_sessions: number | null;
+        };
+        Relationships: [];
+      };
       daily_notification_stats: {
         Row: {
-          channel: string | null
-          stat_date: string | null
-          total_clicked: number | null
-          total_delivered: number | null
-          total_opened: number | null
-          total_sent: number | null
-          type: Database["public"]["Enums"]["notification_type"] | null
-        }
-        Relationships: []
-      }
+          channel: string | null;
+          stat_date: string | null;
+          total_clicked: number | null;
+          total_delivered: number | null;
+          total_opened: number | null;
+          total_sent: number | null;
+          type: Database['public']['Enums']['notification_type'] | null;
+        };
+        Relationships: [];
+      };
       database_schema_summary: {
         Row: {
-          object_type: string | null
-          schema_name: unknown | null
-          table_name: unknown | null
-          view_definition: string | null
-        }
-        Relationships: []
-      }
+          object_type: string | null;
+          schema_name: unknown | null;
+          table_name: unknown | null;
+          view_definition: string | null;
+        };
+        Relationships: [];
+      };
       mfa_admin_dashboard: {
         Row: {
-          active_mfa_sessions: number | null
-          email: string | null
-          failed_verifications_24h: number | null
-          full_name: string | null
-          last_mfa_activity: string | null
-          mfa_enabled: boolean | null
-          mfa_setup_completed: boolean | null
-          role: Database["public"]["Enums"]["user_role"] | null
-          successful_verifications_24h: number | null
-          trusted_devices_count: number | null
-          user_id: string | null
-        }
-        Relationships: []
-      }
+          active_mfa_sessions: number | null;
+          email: string | null;
+          failed_verifications_24h: number | null;
+          full_name: string | null;
+          last_mfa_activity: string | null;
+          mfa_enabled: boolean | null;
+          mfa_setup_completed: boolean | null;
+          role: Database['public']['Enums']['user_role'] | null;
+          successful_verifications_24h: number | null;
+          trusted_devices_count: number | null;
+          user_id: string | null;
+        };
+        Relationships: [];
+      };
       mfa_statistics: {
         Row: {
-          active_mfa_users_24h: number | null
-          failed_attempts_24h: number | null
-          new_mfa_setups_7d: number | null
-          users_with_mfa_enabled: number | null
-          users_without_mfa: number | null
-        }
-        Relationships: []
-      }
+          active_mfa_users_24h: number | null;
+          failed_attempts_24h: number | null;
+          new_mfa_setups_7d: number | null;
+          users_with_mfa_enabled: number | null;
+          users_without_mfa: number | null;
+        };
+        Relationships: [];
+      };
       security_dashboard: {
         Row: {
-          event_count: number | null
-          event_type: string | null
-          hour: string | null
-          severity: string | null
-          unique_ips: number | null
-          unique_users: number | null
-        }
-        Relationships: []
-      }
+          event_count: number | null;
+          event_type: string | null;
+          hour: string | null;
+          severity: string | null;
+          unique_ips: number | null;
+          unique_users: number | null;
+        };
+        Relationships: [];
+      };
       session_details: {
         Row: {
-          client_email: string | null
-          client_name: string | null
-          coach_email: string | null
-          coach_name: string | null
-          created_at: string | null
-          duration_minutes: number | null
-          id: string | null
-          meeting_url: string | null
-          rating: number | null
-          review: string | null
-          scheduled_at: string | null
-          status: Database["public"]["Enums"]["session_status"] | null
-          title: string | null
-          updated_at: string | null
-        }
-        Relationships: []
-      }
+          client_email: string | null;
+          client_name: string | null;
+          coach_email: string | null;
+          coach_name: string | null;
+          created_at: string | null;
+          duration_minutes: number | null;
+          id: string | null;
+          meeting_url: string | null;
+          rating: number | null;
+          review: string | null;
+          scheduled_at: string | null;
+          status: Database['public']['Enums']['session_status'] | null;
+          title: string | null;
+          updated_at: string | null;
+        };
+        Relationships: [];
+      };
       user_accessible_files: {
         Row: {
-          access_type: string | null
-          bucket_name: string | null
-          created_at: string | null
-          description: string | null
-          download_count: number | null
-          expires_at: string | null
-          file_category: Database["public"]["Enums"]["file_category"] | null
-          file_size: number | null
-          file_type: string | null
-          filename: string | null
-          id: string | null
-          is_shared: boolean | null
-          original_filename: string | null
-          owner_name: string | null
+          access_type: string | null;
+          bucket_name: string | null;
+          created_at: string | null;
+          description: string | null;
+          download_count: number | null;
+          expires_at: string | null;
+          file_category: Database['public']['Enums']['file_category'] | null;
+          file_size: number | null;
+          file_type: string | null;
+          filename: string | null;
+          id: string | null;
+          is_shared: boolean | null;
+          original_filename: string | null;
+          owner_name: string | null;
           permission_type:
-            | Database["public"]["Enums"]["file_permission_type"]
-            | null
-          session_id: string | null
-          storage_path: string | null
-          tags: string[] | null
-          updated_at: string | null
-          user_id: string | null
-        }
+            | Database['public']['Enums']['file_permission_type']
+            | null;
+          session_id: string | null;
+          storage_path: string | null;
+          tags: string[] | null;
+          updated_at: string | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "file_uploads_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "session_details"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_uploads_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'session_details';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_uploads_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_uploads_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "client_progress_summary"
-            referencedColumns: ["client_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'client_progress_summary';
+            referencedColumns: ['client_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_statistics"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_statistics';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "coach_stats"
-            referencedColumns: ["coach_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'coach_stats';
+            referencedColumns: ['coach_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "mfa_admin_dashboard"
-            referencedColumns: ["user_id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'mfa_admin_dashboard';
+            referencedColumns: ['user_id'];
           },
           {
-            foreignKeyName: "file_uploads_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'file_uploads_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Functions: {
       block_ip_address: {
         Args: {
-          p_reason: string
-          p_expires_at?: string
-          p_ip_address: unknown
-          p_blocked_by?: string
-        }
-        Returns: string
-      }
+          p_reason: string;
+          p_expires_at?: string;
+          p_ip_address: unknown;
+          p_blocked_by?: string;
+        };
+        Returns: string;
+      };
       can_send_notification: {
         Args: {
-          sender_id: string
-          recipient_id: string
-          notification_type: Database["public"]["Enums"]["notification_type"]
-        }
-        Returns: boolean
-      }
+          sender_id: string;
+          recipient_id: string;
+          notification_type: Database['public']['Enums']['notification_type'];
+        };
+        Returns: boolean;
+      };
       can_user_message_user: {
-        Args: { recipient_id: string; sender_id: string }
-        Returns: boolean
-      }
+        Args: { recipient_id: string; sender_id: string };
+        Returns: boolean;
+      };
       cancel_scheduled_notifications: {
         Args: {
-          filter_session_id?: string
-          filter_channel?: string
-          filter_type?: Database["public"]["Enums"]["notification_type"]
-          filter_user_id?: string
-        }
-        Returns: number
-      }
+          filter_session_id?: string;
+          filter_channel?: string;
+          filter_type?: Database['public']['Enums']['notification_type'];
+          filter_user_id?: string;
+        };
+        Returns: number;
+      };
       check_connection: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       check_mfa_ip_rate_limit: {
         Args: {
-          ip_addr: unknown
-          user_uuid: string
-          time_window?: unknown
-          max_attempts?: number
-        }
-        Returns: boolean
-      }
+          ip_addr: unknown;
+          user_uuid: string;
+          time_window?: unknown;
+          max_attempts?: number;
+        };
+        Returns: boolean;
+      };
       check_mfa_rate_limit: {
-        Args: { method_type_param?: string; target_user_id: string }
-        Returns: boolean
-      }
+        Args: { method_type_param?: string; target_user_id: string };
+        Returns: boolean;
+      };
       check_suspicious_activity: {
-        Args: { time_window?: unknown; user_id: string }
-        Returns: Json
-      }
+        Args: { time_window?: unknown; user_id: string };
+        Returns: Json;
+      };
       cleanup_expired_file_shares: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_expired_mfa_sessions: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_expired_quarantined_files: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_expired_shares: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_expired_typing_indicators: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       cleanup_expired_virus_scan_cache: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_mfa_data: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_notification_analytics_data: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          inactive_subscriptions_deleted: number
-          old_scheduled_deleted: number
-          old_logs_deleted: number
-        }[]
-      }
+          inactive_subscriptions_deleted: number;
+          old_scheduled_deleted: number;
+          old_logs_deleted: number;
+        }[];
+      };
       cleanup_notification_system: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          scheduled_notifications_cleaned: number
-          delivery_logs_cleaned: number
-          jobs_cleaned: number
-        }[]
-      }
+          scheduled_notifications_cleaned: number;
+          delivery_logs_cleaned: number;
+          jobs_cleaned: number;
+        }[];
+      };
       cleanup_old_logs: {
-        Args: { p_days?: number; p_dry_run?: boolean }
+        Args: { p_days?: number; p_dry_run?: boolean };
         Returns: {
-          table_name: string
-          records_to_delete: number
-          oldest_record: string
-          newest_record: string
-        }[]
-      }
+          table_name: string;
+          records_to_delete: number;
+          oldest_record: string;
+          newest_record: string;
+        }[];
+      };
       cleanup_old_mfa_data: {
-        Args: { events_retention?: unknown; attempts_retention?: unknown }
-        Returns: number
-      }
+        Args: { events_retention?: unknown; attempts_retention?: unknown };
+        Returns: number;
+      };
       cleanup_old_notifications: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_old_push_subscriptions: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       cleanup_old_security_logs: {
-        Args: { retention_days?: number }
+        Args: { retention_days?: number };
         Returns: {
-          deleted_violations: number
-          expired_blocks: number
-          deleted_logs: number
-        }[]
-      }
+          deleted_violations: number;
+          expired_blocks: number;
+          deleted_logs: number;
+        }[];
+      };
       comprehensive_database_cleanup: {
-        Args: { dry_run?: boolean }
+        Args: { dry_run?: boolean };
         Returns: {
-          records_affected: number
-          cleanup_type: string
-          action_taken: string
-        }[]
-      }
+          records_affected: number;
+          cleanup_type: string;
+          action_taken: string;
+        }[];
+      };
       create_file_version: {
         Args: {
-          p_file_size: number
-          p_file_type: string
-          p_original_filename: string
-          p_filename: string
-          p_storage_path: string
-          p_file_hash: string
-          p_change_summary?: string
-          p_is_major_version?: boolean
-          p_created_by?: string
-          p_description?: string
-          p_file_id: string
-        }
-        Returns: string
-      }
+          p_file_size: number;
+          p_file_type: string;
+          p_original_filename: string;
+          p_filename: string;
+          p_storage_path: string;
+          p_file_hash: string;
+          p_change_summary?: string;
+          p_is_major_version?: boolean;
+          p_created_by?: string;
+          p_description?: string;
+          p_file_id: string;
+        };
+        Returns: string;
+      };
       create_notification_from_template: {
         Args: {
-          input_type: Database["public"]["Enums"]["notification_type"]
-          template_variables?: Json
-          scheduled_for?: string
-          priority?: string
-          input_user_id: string
-          input_channel?: string
-        }
-        Returns: string
-      }
+          input_type: Database['public']['Enums']['notification_type'];
+          template_variables?: Json;
+          scheduled_for?: string;
+          priority?: string;
+          input_user_id: string;
+          input_channel?: string;
+        };
+        Returns: string;
+      };
       create_session: {
         Args: {
-          title: string
-          coach_id: string
-          description?: string
-          duration_minutes?: number
-          scheduled_at: string
-          client_id: string
-        }
-        Returns: string
-      }
+          title: string;
+          coach_id: string;
+          description?: string;
+          duration_minutes?: number;
+          scheduled_at: string;
+          client_id: string;
+        };
+        Returns: string;
+      };
       create_temporary_file_share: {
         Args: {
-          p_file_id: string
-          p_expires_at: string
-          p_created_by: string
-          p_password_hash?: string
-          p_max_downloads?: number
-          p_description?: string
-        }
+          p_file_id: string;
+          p_expires_at: string;
+          p_created_by: string;
+          p_password_hash?: string;
+          p_max_downloads?: number;
+          p_description?: string;
+        };
         Returns: {
-          created_at: string | null
-          created_by: string
-          current_downloads: number | null
-          description: string | null
-          expires_at: string
-          file_id: string
-          id: string
-          is_active: boolean | null
-          max_downloads: number | null
-          metadata: Json | null
-          password_hash: string | null
-          share_token: string
-          updated_at: string | null
-        }
-      }
+          created_at: string | null;
+          created_by: string;
+          current_downloads: number | null;
+          description: string | null;
+          expires_at: string;
+          file_id: string;
+          id: string;
+          is_active: boolean | null;
+          max_downloads: number | null;
+          metadata: Json | null;
+          password_hash: string | null;
+          share_token: string;
+          updated_at: string | null;
+        };
+      };
       custom_access_token_hook: {
-        Args: { event: Json }
-        Returns: Json
-      }
+        Args: { event: Json };
+        Returns: Json;
+      };
       db_health_check: {
-        Args: Record<PropertyKey, never>
-        Returns: Json
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: Json;
+      };
       decrypt_totp_secret: {
-        Args: { encrypted_secret: string; user_id: string; secret_salt: string }
-        Returns: string
-      }
+        Args: {
+          encrypted_secret: string;
+          user_id: string;
+          secret_salt: string;
+        };
+        Returns: string;
+      };
       encrypt_totp_secret: {
-        Args: { secret: string; user_id: string }
+        Args: { secret: string; user_id: string };
         Returns: {
-          salt: string
-          encrypted_secret: string
-        }[]
-      }
+          salt: string;
+          encrypted_secret: string;
+        }[];
+      };
       generate_backup_codes: {
         Args:
           | { code_count?: number; user_uuid: string }
           | {
-              target_user_id: string
-              code_length?: number
-              codes_count?: number
-            }
-        Returns: string[]
-      }
+              target_user_id: string;
+              code_length?: number;
+              codes_count?: number;
+            };
+        Returns: string[];
+      };
       generate_share_token: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       get_active_connections: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       get_available_time_slots: {
-        Args: { slot_duration?: number; coach_id: string; target_date: string }
+        Args: { slot_duration?: number; coach_id: string; target_date: string };
         Returns: {
-          is_available: boolean
-          end_time: string
-          start_time: string
-        }[]
-      }
+          is_available: boolean;
+          end_time: string;
+          start_time: string;
+        }[];
+      };
       get_coach_average_rating: {
         Args:
           | { coach_uuid: string }
-          | { end_date?: string; p_coach_id: string; start_date?: string }
-        Returns: number
-      }
+          | { end_date?: string; p_coach_id: string; start_date?: string };
+        Returns: number;
+      };
       get_coach_performance_metrics: {
-        Args: { start_date: string; end_date: string }
+        Args: { start_date: string; end_date: string };
         Returns: {
-          active_clients: number
-          completed_sessions: number
-          coach_id: string
-          total_sessions: number
-          completion_rate: number
-          coach_name: string
-        }[]
-      }
+          active_clients: number;
+          completed_sessions: number;
+          coach_id: string;
+          total_sessions: number;
+          completion_rate: number;
+          coach_name: string;
+        }[];
+      };
       get_daily_notification_stats: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          total_failed: number
-          avg_delivery_time_minutes: number
-          stat_date: string
-          total_sent: number
-          total_delivered: number
-          delivery_rate: number
-        }[]
-      }
+          total_failed: number;
+          avg_delivery_time_minutes: number;
+          stat_date: string;
+          total_sent: number;
+          total_delivered: number;
+          delivery_rate: number;
+        }[];
+      };
       get_daily_session_metrics: {
-        Args: { end_date: string; start_date: string }
+        Args: { end_date: string; start_date: string };
         Returns: {
-          date: string
-          total_sessions: number
-          completed_sessions: number
-          cancelled_sessions: number
-          scheduled_sessions: number
-          completion_rate: number
-        }[]
-      }
+          date: string;
+          total_sessions: number;
+          completed_sessions: number;
+          cancelled_sessions: number;
+          scheduled_sessions: number;
+          completion_rate: number;
+        }[];
+      };
       get_daily_user_growth: {
-        Args: { end_date: string; start_date: string }
+        Args: { end_date: string; start_date: string };
         Returns: {
-          total_users: number
-          date: string
-          new_users: number
-          active_users: number
-        }[]
-      }
+          total_users: number;
+          date: string;
+          new_users: number;
+          active_users: number;
+        }[];
+      };
       get_database_size: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       get_database_statistics: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          index_size: string
-          table_size: string
-          record_count: number
-          table_name: string
-        }[]
-      }
+          index_size: string;
+          table_size: string;
+          record_count: number;
+          table_name: string;
+        }[];
+      };
       get_enhanced_coach_performance_metrics: {
-        Args: { end_date: string; start_date: string }
+        Args: { end_date: string; start_date: string };
         Returns: {
-          completion_rate: number
-          total_ratings: number
-          active_clients: number
-          completed_sessions: number
-          average_rating: number
-          coach_id: string
-          coach_name: string
-          total_sessions: number
-        }[]
-      }
+          completion_rate: number;
+          total_ratings: number;
+          active_clients: number;
+          completed_sessions: number;
+          average_rating: number;
+          coach_id: string;
+          coach_name: string;
+          total_sessions: number;
+        }[];
+      };
       get_file_download_stats: {
-        Args: { p_date_to?: string; p_date_from?: string; p_file_id: string }
-        Returns: Json
-      }
+        Args: { p_date_to?: string; p_date_from?: string; p_file_id: string };
+        Returns: Json;
+      };
       get_file_version_stats: {
-        Args: { p_file_id: string }
-        Returns: Json
-      }
+        Args: { p_file_id: string };
+        Returns: Json;
+      };
       get_files_shared_with_user: {
-        Args: { user_uuid: string }
+        Args: { user_uuid: string };
         Returns: {
-          file_id: string
-          filename: string
-          file_type: string
-          created_at: string
-          expires_at: string
-          permission_type: Database["public"]["Enums"]["file_permission_type"]
-          shared_by_name: string
-          file_size: number
-        }[]
-      }
+          file_id: string;
+          filename: string;
+          file_type: string;
+          created_at: string;
+          expires_at: string;
+          permission_type: Database['public']['Enums']['file_permission_type'];
+          shared_by_name: string;
+          file_size: number;
+        }[];
+      };
       get_index_usage_stats: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          usage_ratio: number
-          idx_tup_fetch: number
-          idx_tup_read: number
-          indexname: string
-          tablename: string
-          schemaname: string
-          is_unique: boolean
-          index_size: string
-        }[]
-      }
+          usage_ratio: number;
+          idx_tup_fetch: number;
+          idx_tup_read: number;
+          indexname: string;
+          tablename: string;
+          schemaname: string;
+          is_unique: boolean;
+          index_size: string;
+        }[];
+      };
       get_long_running_queries: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       get_next_version_number: {
-        Args: { target_file_id: string }
-        Returns: number
-      }
+        Args: { target_file_id: string };
+        Returns: number;
+      };
       get_notification_delivery_health: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          total_queued: number
-          error_rate: number
-          avg_delivery_time: number
-          failed_notifications: number
-          processing_notifications: number
-        }[]
-      }
+          total_queued: number;
+          error_rate: number;
+          avg_delivery_time: number;
+          failed_notifications: number;
+          processing_notifications: number;
+        }[];
+      };
       get_notification_overview_stats: {
         Args: {
-          filter_channel?: string
-          filter_type?: Database["public"]["Enums"]["notification_type"]
-          start_date: string
-          end_date: string
-        }
+          filter_channel?: string;
+          filter_type?: Database['public']['Enums']['notification_type'];
+          start_date: string;
+          end_date: string;
+        };
         Returns: {
-          total_sent: number
-          total_delivered: number
-          click_rate: number
-          open_rate: number
-          delivery_rate: number
-          total_clicked: number
-          total_opened: number
-        }[]
-      }
+          total_sent: number;
+          total_delivered: number;
+          click_rate: number;
+          open_rate: number;
+          delivery_rate: number;
+          total_clicked: number;
+          total_opened: number;
+        }[];
+      };
       get_notification_preferences_stats: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          inapp_enabled: number
-          marketing_opted_in: number
-          quiet_hours_enabled: number
-          total_users: number
-          email_enabled: number
-          push_enabled: number
-          avg_reminder_timing: number
-        }[]
-      }
+          inapp_enabled: number;
+          marketing_opted_in: number;
+          quiet_hours_enabled: number;
+          total_users: number;
+          email_enabled: number;
+          push_enabled: number;
+          avg_reminder_timing: number;
+        }[];
+      };
       get_notification_queue_stats: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          pending_jobs: number
-          processing_jobs: number
-          failed_jobs: number
-          oldest_pending_notification: string
-          oldest_pending_job: string
-          pending_notifications: number
-          processing_notifications: number
-          failed_notifications: number
-        }[]
-      }
+          pending_jobs: number;
+          processing_jobs: number;
+          failed_jobs: number;
+          oldest_pending_notification: string;
+          oldest_pending_job: string;
+          pending_notifications: number;
+          processing_notifications: number;
+          failed_notifications: number;
+        }[];
+      };
       get_notification_time_series: {
         Args: {
-          end_date: string
-          start_date: string
-          filter_type?: Database["public"]["Enums"]["notification_type"]
-          filter_channel?: string
-          interval_type?: string
-        }
+          end_date: string;
+          start_date: string;
+          filter_type?: Database['public']['Enums']['notification_type'];
+          filter_channel?: string;
+          interval_type?: string;
+        };
         Returns: {
-          clicked: number
-          opened: number
-          delivered: number
-          sent: number
-          date: string
-        }[]
-      }
+          clicked: number;
+          opened: number;
+          delivered: number;
+          sent: number;
+          date: string;
+        }[];
+      };
       get_or_create_direct_conversation: {
-        Args: { p_user2_id: string; p_user1_id: string }
-        Returns: string
-      }
+        Args: { p_user2_id: string; p_user1_id: string };
+        Returns: string;
+      };
       get_popular_files: {
-        Args: { p_limit?: number; p_date_to?: string; p_date_from?: string }
+        Args: { p_limit?: number; p_date_to?: string; p_date_from?: string };
         Returns: {
-          unique_downloaders: number
-          total_downloads: number
-          file_size: number
-          file_type: string
-          filename: string
-          file_id: string
-        }[]
-      }
+          unique_downloaders: number;
+          total_downloads: number;
+          file_size: number;
+          file_type: string;
+          filename: string;
+          file_id: string;
+        }[];
+      };
       get_practice_journal_stats: {
-        Args: { user_id: string }
+        Args: { user_id: string };
         Returns: {
-          total_entries: number
-          entries_this_week: number
-          entries_this_month: number
-          shared_entries: number
-          average_mood: number
-          average_energy: number
-          most_common_emotions: string[]
-          most_common_sensations: string[]
-          practice_streak_days: number
-        }[]
-      }
+          total_entries: number;
+          entries_this_week: number;
+          entries_this_month: number;
+          shared_entries: number;
+          average_mood: number;
+          average_energy: number;
+          most_common_emotions: string[];
+          most_common_sensations: string[];
+          practice_streak_days: number;
+        }[];
+      };
       get_recent_maintenance_operations: {
         Args: {
-          p_action?: Database["public"]["Enums"]["maintenance_action_type"]
-          p_limit?: number
-          p_status?: Database["public"]["Enums"]["maintenance_status"]
-        }
+          p_action?: Database['public']['Enums']['maintenance_action_type'];
+          p_limit?: number;
+          p_status?: Database['public']['Enums']['maintenance_status'];
+        };
         Returns: {
-          duration_ms: number
-          result: Json
-          error_message: string
-          action: Database["public"]["Enums"]["maintenance_action_type"]
-          status: Database["public"]["Enums"]["maintenance_status"]
-          id: string
-          initiated_by_email: string
-          started_at: string
-          completed_at: string
-        }[]
-      }
+          duration_ms: number;
+          result: Json;
+          error_message: string;
+          action: Database['public']['Enums']['maintenance_action_type'];
+          status: Database['public']['Enums']['maintenance_status'];
+          id: string;
+          initiated_by_email: string;
+          started_at: string;
+          completed_at: string;
+        }[];
+      };
       get_security_statistics: {
-        Args: { end_date?: string; start_date?: string }
+        Args: { end_date?: string; start_date?: string };
         Returns: {
-          rate_limit_violations: number
-          top_blocked_ips: Json
-          blocked_ips_count: number
-          high_events: number
-          critical_events: number
-          total_events: number
-          file_security_events: number
-          quarantined_files: number
-          top_attack_types: Json
-        }[]
-      }
+          rate_limit_violations: number;
+          top_blocked_ips: Json;
+          blocked_ips_count: number;
+          high_events: number;
+          critical_events: number;
+          total_events: number;
+          file_security_events: number;
+          quarantined_files: number;
+          top_attack_types: Json;
+        }[];
+      };
       get_share_statistics: {
-        Args: { p_share_id: string }
-        Returns: Json
-      }
+        Args: { p_share_id: string };
+        Returns: Json;
+      };
       get_slow_queries: {
-        Args: { p_limit?: number; p_min_duration?: unknown }
+        Args: { p_limit?: number; p_min_duration?: unknown };
         Returns: {
-          rows_returned: number
-          mean_time: number
-          total_time: number
-          calls: number
-          query_text: string
-        }[]
-      }
+          rows_returned: number;
+          mean_time: number;
+          total_time: number;
+          calls: number;
+          query_text: string;
+        }[];
+      };
       get_system_average_rating: {
-        Args: { start_date?: string; end_date?: string }
-        Returns: number
-      }
+        Args: { start_date?: string; end_date?: string };
+        Returns: number;
+      };
       get_system_health_stats: {
-        Args: { p_hours?: number }
+        Args: { p_hours?: number };
         Returns: {
-          avg_response_time_ms: number
-          error_count: number
-          warning_count: number
-          healthy_count: number
-          check_type: string
-          last_check_at: string
-        }[]
-      }
+          avg_response_time_ms: number;
+          error_count: number;
+          warning_count: number;
+          healthy_count: number;
+          check_type: string;
+          last_check_at: string;
+        }[];
+      };
       get_system_overview_metrics: {
-        Args: { start_date: string; end_date: string }
+        Args: { start_date: string; end_date: string };
         Returns: {
-          total_users: number
-          active_users: number
-          total_sessions: number
-          completed_sessions: number
-          total_revenue: number
-          average_rating: number
-          new_users_this_month: number
-          completion_rate: number
-          total_coaches: number
-          total_clients: number
-          active_coaches: number
-          average_sessions_per_user: number
-        }[]
-      }
+          total_users: number;
+          active_users: number;
+          total_sessions: number;
+          completed_sessions: number;
+          total_revenue: number;
+          average_rating: number;
+          new_users_this_month: number;
+          completion_rate: number;
+          total_coaches: number;
+          total_clients: number;
+          active_coaches: number;
+          average_sessions_per_user: number;
+        }[];
+      };
       get_system_statistics: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          metric_value: number
-          metric_name: string
-          description: string
-          metric_unit: string
-        }[]
-      }
+          metric_value: number;
+          metric_name: string;
+          description: string;
+          metric_unit: string;
+        }[];
+      };
       get_table_sizes: {
-        Args: { p_limit?: number }
+        Args: { p_limit?: number };
         Returns: {
-          row_count: number
-          size_bytes: number
-          size_pretty: string
-          table_name: string
-        }[]
-      }
+          row_count: number;
+          size_bytes: number;
+          size_pretty: string;
+          table_name: string;
+        }[];
+      };
       get_top_performing_notifications: {
-        Args: { end_date: string; start_date: string; limit_count?: number }
+        Args: { end_date: string; start_date: string; limit_count?: number };
         Returns: {
-          open_rate: number
-          sent_count: number
-          title: string
-          type: Database["public"]["Enums"]["notification_type"]
-          id: string
-          click_rate: number
-        }[]
-      }
+          open_rate: number;
+          sent_count: number;
+          title: string;
+          type: Database['public']['Enums']['notification_type'];
+          id: string;
+          click_rate: number;
+        }[];
+      };
       get_unread_message_count: {
-        Args: { p_conversation_id: string; p_user_id: string }
-        Returns: number
-      }
+        Args: { p_conversation_id: string; p_user_id: string };
+        Returns: number;
+      };
       get_unread_notification_count: {
-        Args: { input_user_id: string }
-        Returns: number
-      }
+        Args: { input_user_id: string };
+        Returns: number;
+      };
       get_upcoming_sessions: {
-        Args: { user_id: string }
+        Args: { user_id: string };
         Returns: {
-          title: string
-          id: string
-          scheduled_at: string
-          duration_minutes: number
-          status: Database["public"]["Enums"]["session_status"]
-          coach_name: string
-          client_name: string
-          meeting_url: string
-        }[]
-      }
+          title: string;
+          id: string;
+          scheduled_at: string;
+          duration_minutes: number;
+          status: Database['public']['Enums']['session_status'];
+          coach_name: string;
+          client_name: string;
+          meeting_url: string;
+        }[];
+      };
       get_user_download_history: {
-        Args: { p_offset?: number; p_limit?: number; p_user_id: string }
+        Args: { p_offset?: number; p_limit?: number; p_user_id: string };
         Returns: {
-          downloaded_at: string
-          file_size: number
-          success: boolean
-          file_id: string
-          filename: string
-          file_type: string
-          download_type: string
-          download_id: string
-        }[]
-      }
+          downloaded_at: string;
+          file_size: number;
+          success: boolean;
+          file_id: string;
+          filename: string;
+          file_type: string;
+          download_type: string;
+          download_id: string;
+        }[];
+      };
       get_user_engagement_metrics: {
-        Args: { end_date: string; start_date: string }
+        Args: { end_date: string; start_date: string };
         Returns: {
-          avg_notifications_per_user: number
-          unsubscribe_rate: number
-          engaged_users: number
-          active_users: number
-        }[]
-      }
+          avg_notifications_per_user: number;
+          unsubscribe_rate: number;
+          engaged_users: number;
+          active_users: number;
+        }[];
+      };
       get_user_mfa_status: {
-        Args: { target_user_id: string }
-        Returns: Json
-      }
+        Args: { target_user_id: string };
+        Returns: Json;
+      };
       get_user_role: {
-        Args: Record<PropertyKey, never> | { user_id: string }
-        Returns: string
-      }
+        Args: Record<PropertyKey, never> | { user_id: string };
+        Returns: string;
+      };
       get_user_storage_usage: {
-        Args: { user_uuid: string }
+        Args: { user_uuid: string };
         Returns: {
-          total_size_bytes: number
-          total_files: number
-          total_size_mb: number
-        }[]
-      }
+          total_size_bytes: number;
+          total_files: number;
+          total_size_mb: number;
+        }[];
+      };
       get_version_comparison: {
-        Args: { p_version_b: number; p_file_id: string; p_version_a: number }
-        Returns: Json
-      }
+        Args: { p_version_b: number; p_file_id: string; p_version_a: number };
+        Returns: Json;
+      };
       get_virus_scan_statistics: {
-        Args: { end_date?: string; start_date?: string }
+        Args: { end_date?: string; start_date?: string };
         Returns: {
-          total_scans: number
-          safe_files: number
-          threats_detected: number
-          quarantined_files: number
-          avg_scan_duration_ms: number
-          scans_by_provider: Json
-          top_threats: Json
-        }[]
-      }
+          total_scans: number;
+          safe_files: number;
+          threats_detected: number;
+          quarantined_files: number;
+          avg_scan_duration_ms: number;
+          scans_by_provider: Json;
+          top_threats: Json;
+        }[];
+      };
       increment_file_download_count: {
-        Args: { file_upload_id: string }
-        Returns: undefined
-      }
+        Args: { file_upload_id: string };
+        Returns: undefined;
+      };
       is_admin: {
-        Args: Record<PropertyKey, never> | { user_id?: string }
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never> | { user_id?: string };
+        Returns: boolean;
+      };
       is_client: {
-        Args: Record<PropertyKey, never> | { user_id: string }
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never> | { user_id: string };
+        Returns: boolean;
+      };
       is_coach: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       is_ip_blocked: {
-        Args: { check_ip: unknown }
-        Returns: boolean
-      }
+        Args: { check_ip: unknown };
+        Returns: boolean;
+      };
       is_time_slot_available: {
         Args: {
-          duration_minutes?: number
-          coach_id: string
-          start_time: string
-        }
-        Returns: boolean
-      }
+          duration_minutes?: number;
+          coach_id: string;
+          start_time: string;
+        };
+        Returns: boolean;
+      };
       log_audit_event: {
         Args:
           | {
-              p_action: Database["public"]["Enums"]["audit_action_type"]
-              p_resource?: string
-              p_resource_id?: string
-              p_description?: string
-              p_metadata?: Json
-              p_risk_level?: string
-              p_ip_address?: unknown
-              p_user_agent?: string
-              p_user_id: string
+              p_action: Database['public']['Enums']['audit_action_type'];
+              p_resource?: string;
+              p_resource_id?: string;
+              p_description?: string;
+              p_metadata?: Json;
+              p_risk_level?: string;
+              p_ip_address?: unknown;
+              p_user_agent?: string;
+              p_user_id: string;
             }
           | {
-              resource_id_value?: string
-              details_json?: Json
-              ip_addr?: unknown
-              user_agent_string?: string
-              action_name: string
-              resource_type_name?: string
-            }
-        Returns: string
-      }
+              resource_id_value?: string;
+              details_json?: Json;
+              ip_addr?: unknown;
+              user_agent_string?: string;
+              action_name: string;
+              resource_type_name?: string;
+            };
+        Returns: string;
+      };
       log_file_download: {
         Args: {
-          p_downloaded_by?: string
-          p_user_agent?: string
-          p_city?: string
-          p_client_info?: Json
-          p_country_code?: string
-          p_file_size_at_download?: number
-          p_download_duration_ms?: number
-          p_ip_address?: unknown
-          p_share_id?: string
-          p_download_type?: string
-          p_bandwidth_used?: number
-          p_failure_reason?: string
-          p_success?: boolean
-          p_file_id: string
-        }
-        Returns: string
-      }
+          p_downloaded_by?: string;
+          p_user_agent?: string;
+          p_city?: string;
+          p_client_info?: Json;
+          p_country_code?: string;
+          p_file_size_at_download?: number;
+          p_download_duration_ms?: number;
+          p_ip_address?: unknown;
+          p_share_id?: string;
+          p_download_type?: string;
+          p_bandwidth_used?: number;
+          p_failure_reason?: string;
+          p_success?: boolean;
+          p_file_id: string;
+        };
+        Returns: string;
+      };
       log_file_security_event: {
         Args: {
-          p_file_size?: number
-          p_file_type?: string
-          p_file_id: string
-          p_severity?: Database["public"]["Enums"]["security_severity"]
-          p_file_hash?: string
-          p_user_id: string
-          p_ip_address: unknown
-          p_event_type: string
-          p_quarantined?: boolean
-          p_event_details?: Json
-          p_file_name?: string
-        }
-        Returns: string
-      }
+          p_file_size?: number;
+          p_file_type?: string;
+          p_file_id: string;
+          p_severity?: Database['public']['Enums']['security_severity'];
+          p_file_hash?: string;
+          p_user_id: string;
+          p_ip_address: unknown;
+          p_event_type: string;
+          p_quarantined?: boolean;
+          p_event_details?: Json;
+          p_file_name?: string;
+        };
+        Returns: string;
+      };
       log_maintenance_action: {
         Args: {
-          p_action: Database["public"]["Enums"]["maintenance_action_type"]
-          p_status: Database["public"]["Enums"]["maintenance_status"]
-          p_initiated_by?: string
-          p_parameters?: Json
-          p_result?: Json
-          p_error_message?: string
-        }
-        Returns: string
-      }
+          p_action: Database['public']['Enums']['maintenance_action_type'];
+          p_status: Database['public']['Enums']['maintenance_status'];
+          p_initiated_by?: string;
+          p_parameters?: Json;
+          p_result?: Json;
+          p_error_message?: string;
+        };
+        Returns: string;
+      };
       log_mfa_event: {
         Args: {
-          ip_addr?: unknown
-          event_type_val: Database["public"]["Enums"]["mfa_event_type"]
-          user_uuid: string
-          metadata_val?: Json
-          user_agent_val?: string
-        }
-        Returns: string
-      }
+          ip_addr?: unknown;
+          event_type_val: Database['public']['Enums']['mfa_event_type'];
+          user_uuid: string;
+          metadata_val?: Json;
+          user_agent_val?: string;
+        };
+        Returns: string;
+      };
       log_push_delivery_status: {
         Args: {
-          input_subscription_id: string
-          input_error_message?: string
-          input_provider_response?: Json
-          input_notification_id: string
-          input_status: string
-        }
-        Returns: undefined
-      }
+          input_subscription_id: string;
+          input_error_message?: string;
+          input_provider_response?: Json;
+          input_notification_id: string;
+          input_status: string;
+        };
+        Returns: undefined;
+      };
       log_security_event: {
         Args:
           | {
-              p_severity?: Database["public"]["Enums"]["security_severity"]
-              p_user_id?: string
-              p_user_agent?: string
-              p_referer?: string
-              p_request_path?: string
-              p_request_method?: string
-              p_ip_address: unknown
-              p_activity_type: string
-              p_details?: string
+              p_severity?: Database['public']['Enums']['security_severity'];
+              p_user_id?: string;
+              p_user_agent?: string;
+              p_referer?: string;
+              p_request_path?: string;
+              p_request_method?: string;
+              p_ip_address: unknown;
+              p_activity_type: string;
+              p_details?: string;
             }
           | {
-              user_agent?: string
-              user_id: string
-              event_type: string
-              event_details?: Json
-              severity?: string
-              ip_address?: unknown
-            }
-        Returns: string
-      }
+              user_agent?: string;
+              user_id: string;
+              event_type: string;
+              event_details?: Json;
+              severity?: string;
+              ip_address?: unknown;
+            };
+        Returns: string;
+      };
       log_share_access: {
         Args: {
-          p_user_agent?: string
-          p_ip_address?: unknown
-          p_share_id: string
-          p_bytes_served?: number
-          p_failure_reason?: string
-          p_success?: boolean
-          p_access_type?: string
-        }
-        Returns: string
-      }
+          p_user_agent?: string;
+          p_ip_address?: unknown;
+          p_share_id: string;
+          p_bytes_served?: number;
+          p_failure_reason?: string;
+          p_success?: boolean;
+          p_access_type?: string;
+        };
+        Returns: string;
+      };
       maintenance_cleanup_old_data: {
         Args: {
-          p_date_column: string
-          p_table_name: string
-          p_dry_run?: boolean
-          p_batch_size?: number
-          p_days_old: number
-        }
+          p_date_column: string;
+          p_table_name: string;
+          p_dry_run?: boolean;
+          p_batch_size?: number;
+          p_days_old: number;
+        };
         Returns: {
-          batch_number: number
-          batch_completed_at: string
-          records_deleted: number
-          records_processed: number
-        }[]
-      }
+          batch_number: number;
+          batch_completed_at: string;
+          records_deleted: number;
+          records_processed: number;
+        }[];
+      };
       maintenance_optimize_tables: {
-        Args: { p_analyze_only?: boolean }
+        Args: { p_analyze_only?: boolean };
         Returns: {
-          details: string
-          duration_ms: number
-          status: string
-          operation: string
-          table_name: string
-        }[]
-      }
+          details: string;
+          duration_ms: number;
+          status: string;
+          operation: string;
+          table_name: string;
+        }[];
+      };
       mark_all_notifications_read: {
-        Args: { input_user_id: string }
-        Returns: number
-      }
+        Args: { input_user_id: string };
+        Returns: number;
+      };
       mark_conversation_as_read: {
-        Args: { p_user_id: string; p_conversation_id: string }
-        Returns: undefined
-      }
+        Args: { p_user_id: string; p_conversation_id: string };
+        Returns: undefined;
+      };
       mark_notification_read: {
-        Args: { input_user_id: string; notification_id: string }
-        Returns: boolean
-      }
+        Args: { input_user_id: string; notification_id: string };
+        Returns: boolean;
+      };
       mark_notifications_read: {
-        Args: { user_id: string; notification_ids?: string[] }
-        Returns: number
-      }
+        Args: { user_id: string; notification_ids?: string[] };
+        Returns: number;
+      };
       process_notification_jobs: {
-        Args: { batch_size?: number }
+        Args: { batch_size?: number };
         Returns: {
-          failed_count: number
-          success_count: number
-          processed_count: number
-        }[]
-      }
+          failed_count: number;
+          success_count: number;
+          processed_count: number;
+        }[];
+      };
       quarantine_file: {
         Args: {
-          p_scan_provider: string
-          p_upload_ip?: unknown
-          p_uploaded_by?: string
-          p_scan_details: string
-          p_threat_name: string
-          p_file_type: string
-          p_file_size: number
-          p_file_name: string
-          p_file_hash: string
-        }
-        Returns: string
-      }
+          p_scan_provider: string;
+          p_upload_ip?: unknown;
+          p_uploaded_by?: string;
+          p_scan_details: string;
+          p_threat_name: string;
+          p_file_type: string;
+          p_file_size: number;
+          p_file_name: string;
+          p_file_hash: string;
+        };
+        Returns: string;
+      };
       refresh_daily_notification_stats: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       rollback_to_version: {
         Args: {
-          p_rollback_description?: string
-          p_file_id: string
-          p_target_version: number
-          p_rollback_by: string
-        }
-        Returns: string
-      }
+          p_rollback_description?: string;
+          p_file_id: string;
+          p_target_version: number;
+          p_rollback_by: string;
+        };
+        Returns: string;
+      };
       schedule_session_reminders: {
         Args: {
-          session_title: string
-          participant_ids: string[]
-          session_id: string
-          coach_name: string
-          session_datetime: string
-        }
-        Returns: number
-      }
+          session_title: string;
+          participant_ids: string[];
+          session_id: string;
+          coach_name: string;
+          session_datetime: string;
+        };
+        Returns: number;
+      };
       send_notification: {
         Args:
           | {
-              channel?: string
-              title: string
-              message: string
-              data?: Json
-              notification_type: Database["public"]["Enums"]["notification_type"]
-              priority?: string
-              scheduled_for?: string
-              recipient_id: string
+              channel?: string;
+              title: string;
+              message: string;
+              data?: Json;
+              notification_type: Database['public']['Enums']['notification_type'];
+              priority?: string;
+              scheduled_for?: string;
+              recipient_id: string;
             }
           | {
-              notification_type: Database["public"]["Enums"]["notification_type"]
-              user_id: string
-              title: string
-              message: string
-              data?: Json
-              scheduled_for?: string
-            }
-        Returns: string
-      }
+              notification_type: Database['public']['Enums']['notification_type'];
+              user_id: string;
+              title: string;
+              message: string;
+              data?: Json;
+              scheduled_for?: string;
+            };
+        Returns: string;
+      };
       send_push_notification: {
         Args: {
-          input_user_id: string
-          notification_body: string
-          notification_title: string
-          notification_data?: Json
-          notification_options?: Json
-        }
-        Returns: boolean
-      }
+          input_user_id: string;
+          notification_body: string;
+          notification_title: string;
+          notification_data?: Json;
+          notification_options?: Json;
+        };
+        Returns: boolean;
+      };
       share_journal_entry_with_coach: {
-        Args: { entry_id: string }
+        Args: { entry_id: string };
         Returns: {
-          body_areas: string[] | null
-          client_id: string
-          content: string
-          created_at: string | null
-          emotions: string[] | null
-          energy_level: number | null
-          id: string
-          insights: string | null
-          mood_rating: number | null
-          practices_done: string[] | null
-          sensations: string[] | null
-          session_id: string | null
-          shared_at: string | null
-          shared_with_coach: boolean | null
-          title: string | null
-          updated_at: string | null
-        }
-      }
+          body_areas: string[] | null;
+          client_id: string;
+          content: string;
+          created_at: string | null;
+          emotions: string[] | null;
+          energy_level: number | null;
+          id: string;
+          insights: string | null;
+          mood_rating: number | null;
+          practices_done: string[] | null;
+          sensations: string[] | null;
+          session_id: string | null;
+          shared_at: string | null;
+          shared_with_coach: boolean | null;
+          title: string | null;
+          updated_at: string | null;
+        };
+      };
       sync_user_role_to_jwt: {
-        Args: { target_user_id: string }
-        Returns: boolean
-      }
+        Args: { target_user_id: string };
+        Returns: boolean;
+      };
       test_database_security_functions: {
-        Args: Record<PropertyKey, never>
-        Returns: Json
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: Json;
+      };
       test_jwt_role_setup: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          details: string
-          test_name: string
-          status: string
-        }[]
-      }
+          details: string;
+          test_name: string;
+          status: string;
+        }[];
+      };
       track_file_share_access: {
-        Args: { share_id: string }
-        Returns: undefined
-      }
+        Args: { share_id: string };
+        Returns: undefined;
+      };
       unblock_ip_address: {
         Args: {
-          p_unblocked_by: string
-          p_ip_address: unknown
-          p_unblock_reason?: string
-        }
-        Returns: boolean
-      }
+          p_unblocked_by: string;
+          p_ip_address: unknown;
+          p_unblock_reason?: string;
+        };
+        Returns: boolean;
+      };
       unshare_journal_entry: {
-        Args: { entry_id: string }
+        Args: { entry_id: string };
         Returns: {
-          body_areas: string[] | null
-          client_id: string
-          content: string
-          created_at: string | null
-          emotions: string[] | null
-          energy_level: number | null
-          id: string
-          insights: string | null
-          mood_rating: number | null
-          practices_done: string[] | null
-          sensations: string[] | null
-          session_id: string | null
-          shared_at: string | null
-          shared_with_coach: boolean | null
-          title: string | null
-          updated_at: string | null
-        }
-      }
+          body_areas: string[] | null;
+          client_id: string;
+          content: string;
+          created_at: string | null;
+          emotions: string[] | null;
+          energy_level: number | null;
+          id: string;
+          insights: string | null;
+          mood_rating: number | null;
+          practices_done: string[] | null;
+          sensations: string[] | null;
+          session_id: string | null;
+          shared_at: string | null;
+          shared_with_coach: boolean | null;
+          title: string | null;
+          updated_at: string | null;
+        };
+      };
       update_push_subscription_status: {
-        Args: { subscription_endpoint: string; is_active_status: boolean }
-        Returns: boolean
-      }
+        Args: { subscription_endpoint: string; is_active_status: boolean };
+        Returns: boolean;
+      };
       update_system_health: {
         Args: {
-          health_metrics?: Json
-          health_status: string
-          component_name: string
-        }
-        Returns: undefined
-      }
+          health_metrics?: Json;
+          health_status: string;
+          component_name: string;
+        };
+        Returns: undefined;
+      };
       update_user_auth_metadata: {
-        Args: { user_id: string; user_role: string }
-        Returns: undefined
-      }
+        Args: { user_id: string; user_role: string };
+        Returns: undefined;
+      };
       use_backup_code: {
-        Args: { backup_code: string; user_uuid: string }
-        Returns: boolean
-      }
+        Args: { backup_code: string; user_uuid: string };
+        Returns: boolean;
+      };
       user_has_version_access: {
         Args: {
-          required_permission?: string
-          user_id: string
-          version_id: string
-        }
-        Returns: boolean
-      }
+          required_permission?: string;
+          user_id: string;
+          version_id: string;
+        };
+        Returns: boolean;
+      };
       validate_mfa_enforcement: {
-        Args: { p_user_id: string }
-        Returns: boolean
-      }
+        Args: { p_user_id: string };
+        Returns: boolean;
+      };
       validate_security_context: {
-        Args: { p_user_id: string; p_action?: string }
-        Returns: Json
-      }
+        Args: { p_user_id: string; p_action?: string };
+        Returns: Json;
+      };
       validate_session_access: {
-        Args: { session_id: string; user_id: string; action?: string }
-        Returns: boolean
-      }
+        Args: { session_id: string; user_id: string; action?: string };
+        Returns: boolean;
+      };
       validate_session_availability_with_timezone: {
         Args: {
-          p_duration_minutes: number
-          p_scheduled_at: string
-          p_coach_id: string
-          p_coach_timezone?: string
-        }
-        Returns: boolean
-      }
+          p_duration_minutes: number;
+          p_scheduled_at: string;
+          p_coach_id: string;
+          p_coach_timezone?: string;
+        };
+        Returns: boolean;
+      };
       validate_temporary_share_access: {
-        Args: { p_share_token: string; p_password?: string }
+        Args: { p_share_token: string; p_password?: string };
         Returns: {
-          share_id: string
-          file_id: string
-          can_access: boolean
-          failure_reason: string
-          file_info: Json
-        }[]
-      }
+          share_id: string;
+          file_id: string;
+          can_access: boolean;
+          failure_reason: string;
+          file_info: Json;
+        }[];
+      };
       validate_user_access: {
-        Args: { accessing_user_id: string; target_user_id: string }
-        Returns: boolean
-      }
+        Args: { accessing_user_id: string; target_user_id: string };
+        Returns: boolean;
+      };
       validate_user_role: {
         Args: {
-          user_id: string
-          expected_role: Database["public"]["Enums"]["user_role"]
-        }
-        Returns: boolean
-      }
+          user_id: string;
+          expected_role: Database['public']['Enums']['user_role'];
+        };
+        Returns: boolean;
+      };
       verify_backup_code: {
         Args: {
-          target_user_id: string
-          client_ip?: unknown
-          client_user_agent?: string
-          provided_code: string
-        }
-        Returns: boolean
-      }
+          target_user_id: string;
+          client_ip?: unknown;
+          client_user_agent?: string;
+          provided_code: string;
+        };
+        Returns: boolean;
+      };
       verify_database_integrity: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          check_name: string
-          status: string
-          details: string
-        }[]
-      }
-    }
+          check_name: string;
+          status: string;
+          details: string;
+        }[];
+      };
+    };
     Enums: {
-      attachment_type: "image" | "document" | "video" | "audio" | "other"
+      attachment_type: 'image' | 'document' | 'video' | 'audio' | 'other';
       audit_action_type:
-        | "login"
-        | "logout"
-        | "view_data"
-        | "create_record"
-        | "update_record"
-        | "delete_record"
-        | "export_data"
-        | "import_data"
-        | "maintenance_action"
-        | "security_event"
-        | "system_configuration"
-      backup_code_status: "active" | "used" | "expired"
-      conversation_type: "direct" | "group"
+        | 'login'
+        | 'logout'
+        | 'view_data'
+        | 'create_record'
+        | 'update_record'
+        | 'delete_record'
+        | 'export_data'
+        | 'import_data'
+        | 'maintenance_action'
+        | 'security_event'
+        | 'system_configuration';
+      backup_code_status: 'active' | 'used' | 'expired';
+      conversation_type: 'direct' | 'group';
       file_category:
-        | "preparation"
-        | "notes"
-        | "recording"
-        | "resource"
-        | "personal"
-        | "avatar"
-        | "document"
-      file_permission_type: "view" | "download" | "edit"
-      language: "en" | "he"
+        | 'preparation'
+        | 'notes'
+        | 'recording'
+        | 'resource'
+        | 'personal'
+        | 'avatar'
+        | 'document';
+      file_permission_type: 'view' | 'download' | 'edit';
+      language: 'en' | 'he';
       maintenance_action_type:
-        | "backup_database"
-        | "database_health_check"
-        | "clear_cache"
-        | "get_cache_stats"
-        | "export_logs"
-        | "cleanup_logs"
-        | "clean_temp_files"
-        | "system_cleanup"
-        | "update_configuration"
-        | "restart_services"
+        | 'backup_database'
+        | 'database_health_check'
+        | 'clear_cache'
+        | 'get_cache_stats'
+        | 'export_logs'
+        | 'cleanup_logs'
+        | 'clean_temp_files'
+        | 'system_cleanup'
+        | 'update_configuration'
+        | 'restart_services';
       maintenance_status:
-        | "started"
-        | "in_progress"
-        | "completed"
-        | "failed"
-        | "partial"
-        | "cancelled"
-        | "timeout"
-      message_status: "sent" | "delivered" | "read"
-      message_type: "text" | "file" | "system"
+        | 'started'
+        | 'in_progress'
+        | 'completed'
+        | 'failed'
+        | 'partial'
+        | 'cancelled'
+        | 'timeout';
+      message_status: 'sent' | 'delivered' | 'read';
+      message_type: 'text' | 'file' | 'system';
       mfa_event_type:
-        | "setup"
-        | "enable"
-        | "disable"
-        | "verify_success"
-        | "verify_failure"
-        | "backup_code_used"
-        | "backup_codes_regenerated"
-      mfa_method: "totp" | "backup_code"
-      mfa_method_type: "totp" | "sms" | "email" | "webauthn"
-      mfa_status: "pending" | "active" | "disabled" | "suspended"
-      mfa_verification_status: "success" | "failed" | "expired" | "rate_limited"
+        | 'setup'
+        | 'enable'
+        | 'disable'
+        | 'verify_success'
+        | 'verify_failure'
+        | 'backup_code_used'
+        | 'backup_codes_regenerated';
+      mfa_method: 'totp' | 'backup_code';
+      mfa_method_type: 'totp' | 'sms' | 'email' | 'webauthn';
+      mfa_status: 'pending' | 'active' | 'disabled' | 'suspended';
+      mfa_verification_status:
+        | 'success'
+        | 'failed'
+        | 'expired'
+        | 'rate_limited';
       notification_type:
-        | "session_reminder"
-        | "session_confirmation"
-        | "new_message"
-        | "system_update"
-        | "welcome_message"
-        | "goal_achieved"
-        | "appointment_reminder"
-        | "coach_message"
-        | "client_message"
-        | "session_cancelled"
-        | "session_rescheduled"
-        | "reflection_reminder"
-        | "system_announcement"
-        | "payment_reminder"
-      privacy_level: "private" | "shared_with_client"
-      security_severity: "low" | "medium" | "high" | "critical"
+        | 'session_reminder'
+        | 'session_confirmation'
+        | 'new_message'
+        | 'system_update'
+        | 'welcome_message'
+        | 'goal_achieved'
+        | 'appointment_reminder'
+        | 'coach_message'
+        | 'client_message'
+        | 'session_cancelled'
+        | 'session_rescheduled'
+        | 'reflection_reminder'
+        | 'system_announcement'
+        | 'payment_reminder';
+      privacy_level: 'private' | 'shared_with_client';
+      security_severity: 'low' | 'medium' | 'high' | 'critical';
       session_status:
-        | "scheduled"
-        | "in_progress"
-        | "completed"
-        | "cancelled"
-        | "rescheduled"
-        | "no_show"
-      user_role: "client" | "coach" | "admin"
-      user_status: "active" | "inactive" | "suspended"
-    }
+        | 'scheduled'
+        | 'in_progress'
+        | 'completed'
+        | 'cancelled'
+        | 'rescheduled'
+        | 'no_show';
+      task_notification_status:
+        | 'SCHEDULED'
+        | 'PROCESSING'
+        | 'SENT'
+        | 'FAILED'
+        | 'CANCELLED';
+      task_notification_type:
+        | 'ASSIGNMENT_CREATED'
+        | 'UPCOMING_DUE'
+        | 'OVERDUE'
+        | 'RECURRING_PROMPT';
+      task_priority: 'LOW' | 'MEDIUM' | 'HIGH';
+      task_status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'OVERDUE';
+      user_role: 'client' | 'coach' | 'admin';
+      user_status: 'active' | 'inactive' | 'suspended';
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   storage: {
     Tables: {
       buckets: {
         Row: {
-          allowed_mime_types: string[] | null
-          avif_autodetection: boolean | null
-          created_at: string | null
-          file_size_limit: number | null
-          id: string
-          name: string
-          owner: string | null
-          owner_id: string | null
-          public: boolean | null
-          updated_at: string | null
-        }
+          allowed_mime_types: string[] | null;
+          avif_autodetection: boolean | null;
+          created_at: string | null;
+          file_size_limit: number | null;
+          id: string;
+          name: string;
+          owner: string | null;
+          owner_id: string | null;
+          public: boolean | null;
+          updated_at: string | null;
+        };
         Insert: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id: string
-          name: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id: string;
+          name: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
         Update: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id?: string
-          name?: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id?: string;
+          name?: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       migrations: {
         Row: {
-          executed_at: string | null
-          hash: string
-          id: number
-          name: string
-        }
+          executed_at: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
         Insert: {
-          executed_at?: string | null
-          hash: string
-          id: number
-          name: string
-        }
+          executed_at?: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
         Update: {
-          executed_at?: string | null
-          hash?: string
-          id?: number
-          name?: string
-        }
-        Relationships: []
-      }
+          executed_at?: string | null;
+          hash?: string;
+          id?: number;
+          name?: string;
+        };
+        Relationships: [];
+      };
       objects: {
         Row: {
-          bucket_id: string | null
-          created_at: string | null
-          id: string
-          last_accessed_at: string | null
-          level: number | null
-          metadata: Json | null
-          name: string | null
-          owner: string | null
-          owner_id: string | null
-          path_tokens: string[] | null
-          updated_at: string | null
-          user_metadata: Json | null
-          version: string | null
-        }
+          bucket_id: string | null;
+          created_at: string | null;
+          id: string;
+          last_accessed_at: string | null;
+          level: number | null;
+          metadata: Json | null;
+          name: string | null;
+          owner: string | null;
+          owner_id: string | null;
+          path_tokens: string[] | null;
+          updated_at: string | null;
+          user_metadata: Json | null;
+          version: string | null;
+        };
         Insert: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          level?: number | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          user_metadata?: Json | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          level?: number | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          user_metadata?: Json | null;
+          version?: string | null;
+        };
         Update: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          level?: number | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          user_metadata?: Json | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          level?: number | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          user_metadata?: Json | null;
+          version?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "objects_bucketId_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: 'objects_bucketId_fkey';
+            columns: ['bucket_id'];
+            isOneToOne: false;
+            referencedRelation: 'buckets';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       prefixes: {
         Row: {
-          bucket_id: string
-          created_at: string | null
-          level: number
-          name: string
-          updated_at: string | null
-        }
+          bucket_id: string;
+          created_at: string | null;
+          level: number;
+          name: string;
+          updated_at: string | null;
+        };
         Insert: {
-          bucket_id: string
-          created_at?: string | null
-          level?: number
-          name: string
-          updated_at?: string | null
-        }
+          bucket_id: string;
+          created_at?: string | null;
+          level?: number;
+          name: string;
+          updated_at?: string | null;
+        };
         Update: {
-          bucket_id?: string
-          created_at?: string | null
-          level?: number
-          name?: string
-          updated_at?: string | null
-        }
+          bucket_id?: string;
+          created_at?: string | null;
+          level?: number;
+          name?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "prefixes_bucketId_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: 'prefixes_bucketId_fkey';
+            columns: ['bucket_id'];
+            isOneToOne: false;
+            referencedRelation: 'buckets';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       s3_multipart_uploads: {
         Row: {
-          bucket_id: string
-          created_at: string
-          id: string
-          in_progress_size: number
-          key: string
-          owner_id: string | null
-          upload_signature: string
-          user_metadata: Json | null
-          version: string
-        }
+          bucket_id: string;
+          created_at: string;
+          id: string;
+          in_progress_size: number;
+          key: string;
+          owner_id: string | null;
+          upload_signature: string;
+          user_metadata: Json | null;
+          version: string;
+        };
         Insert: {
-          bucket_id: string
-          created_at?: string
-          id: string
-          in_progress_size?: number
-          key: string
-          owner_id?: string | null
-          upload_signature: string
-          user_metadata?: Json | null
-          version: string
-        }
+          bucket_id: string;
+          created_at?: string;
+          id: string;
+          in_progress_size?: number;
+          key: string;
+          owner_id?: string | null;
+          upload_signature: string;
+          user_metadata?: Json | null;
+          version: string;
+        };
         Update: {
-          bucket_id?: string
-          created_at?: string
-          id?: string
-          in_progress_size?: number
-          key?: string
-          owner_id?: string | null
-          upload_signature?: string
-          user_metadata?: Json | null
-          version?: string
-        }
+          bucket_id?: string;
+          created_at?: string;
+          id?: string;
+          in_progress_size?: number;
+          key?: string;
+          owner_id?: string | null;
+          upload_signature?: string;
+          user_metadata?: Json | null;
+          version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: 's3_multipart_uploads_bucket_id_fkey';
+            columns: ['bucket_id'];
+            isOneToOne: false;
+            referencedRelation: 'buckets';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       s3_multipart_uploads_parts: {
         Row: {
-          bucket_id: string
-          created_at: string
-          etag: string
-          id: string
-          key: string
-          owner_id: string | null
-          part_number: number
-          size: number
-          upload_id: string
-          version: string
-        }
+          bucket_id: string;
+          created_at: string;
+          etag: string;
+          id: string;
+          key: string;
+          owner_id: string | null;
+          part_number: number;
+          size: number;
+          upload_id: string;
+          version: string;
+        };
         Insert: {
-          bucket_id: string
-          created_at?: string
-          etag: string
-          id?: string
-          key: string
-          owner_id?: string | null
-          part_number: number
-          size?: number
-          upload_id: string
-          version: string
-        }
+          bucket_id: string;
+          created_at?: string;
+          etag: string;
+          id?: string;
+          key: string;
+          owner_id?: string | null;
+          part_number: number;
+          size?: number;
+          upload_id: string;
+          version: string;
+        };
         Update: {
-          bucket_id?: string
-          created_at?: string
-          etag?: string
-          id?: string
-          key?: string
-          owner_id?: string | null
-          part_number?: number
-          size?: number
-          upload_id?: string
-          version?: string
-        }
+          bucket_id?: string;
+          created_at?: string;
+          etag?: string;
+          id?: string;
+          key?: string;
+          owner_id?: string | null;
+          part_number?: number;
+          size?: number;
+          upload_id?: string;
+          version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: 's3_multipart_uploads_parts_bucket_id_fkey';
+            columns: ['bucket_id'];
+            isOneToOne: false;
+            referencedRelation: 'buckets';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
-            columns: ["upload_id"]
-            isOneToOne: false
-            referencedRelation: "s3_multipart_uploads"
-            referencedColumns: ["id"]
+            foreignKeyName: 's3_multipart_uploads_parts_upload_id_fkey';
+            columns: ['upload_id'];
+            isOneToOne: false;
+            referencedRelation: 's3_multipart_uploads';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       add_prefixes: {
-        Args: { _bucket_id: string; _name: string }
-        Returns: undefined
-      }
+        Args: { _bucket_id: string; _name: string };
+        Returns: undefined;
+      };
       can_insert_object: {
-        Args: { name: string; metadata: Json; owner: string; bucketid: string }
-        Returns: undefined
-      }
+        Args: { name: string; metadata: Json; owner: string; bucketid: string };
+        Returns: undefined;
+      };
       delete_prefix: {
-        Args: { _name: string; _bucket_id: string }
-        Returns: boolean
-      }
+        Args: { _name: string; _bucket_id: string };
+        Returns: boolean;
+      };
       extension: {
-        Args: { name: string }
-        Returns: string
-      }
+        Args: { name: string };
+        Returns: string;
+      };
       filename: {
-        Args: { name: string }
-        Returns: string
-      }
+        Args: { name: string };
+        Returns: string;
+      };
       foldername: {
-        Args: { name: string }
-        Returns: string[]
-      }
+        Args: { name: string };
+        Returns: string[];
+      };
       get_level: {
-        Args: { name: string }
-        Returns: number
-      }
+        Args: { name: string };
+        Returns: number;
+      };
       get_prefix: {
-        Args: { name: string }
-        Returns: string
-      }
+        Args: { name: string };
+        Returns: string;
+      };
       get_prefixes: {
-        Args: { name: string }
-        Returns: string[]
-      }
+        Args: { name: string };
+        Returns: string[];
+      };
       get_size_by_bucket: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          size: number
-          bucket_id: string
-        }[]
-      }
+          size: number;
+          bucket_id: string;
+        }[];
+      };
       list_multipart_uploads_with_delimiter: {
         Args: {
-          next_key_token?: string
-          max_keys?: number
-          delimiter_param: string
-          prefix_param: string
-          bucket_id: string
-          next_upload_token?: string
-        }
+          next_key_token?: string;
+          max_keys?: number;
+          delimiter_param: string;
+          prefix_param: string;
+          bucket_id: string;
+          next_upload_token?: string;
+        };
         Returns: {
-          key: string
-          id: string
-          created_at: string
-        }[]
-      }
+          key: string;
+          id: string;
+          created_at: string;
+        }[];
+      };
       list_objects_with_delimiter: {
         Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          start_after?: string
-          next_token?: string
-        }
+          bucket_id: string;
+          prefix_param: string;
+          delimiter_param: string;
+          max_keys?: number;
+          start_after?: string;
+          next_token?: string;
+        };
         Returns: {
-          updated_at: string
-          name: string
-          id: string
-          metadata: Json
-        }[]
-      }
+          updated_at: string;
+          name: string;
+          id: string;
+          metadata: Json;
+        }[];
+      };
       operation: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       search: {
         Args: {
-          limits?: number
-          prefix: string
-          sortorder?: string
-          sortcolumn?: string
-          search?: string
-          offsets?: number
-          levels?: number
-          bucketname: string
-        }
+          limits?: number;
+          prefix: string;
+          sortorder?: string;
+          sortcolumn?: string;
+          search?: string;
+          offsets?: number;
+          levels?: number;
+          bucketname: string;
+        };
         Returns: {
-          metadata: Json
-          last_accessed_at: string
-          created_at: string
-          updated_at: string
-          id: string
-          name: string
-        }[]
-      }
+          metadata: Json;
+          last_accessed_at: string;
+          created_at: string;
+          updated_at: string;
+          id: string;
+          name: string;
+        }[];
+      };
       search_legacy_v1: {
         Args: {
-          prefix: string
-          sortorder?: string
-          sortcolumn?: string
-          search?: string
-          offsets?: number
-          levels?: number
-          limits?: number
-          bucketname: string
-        }
+          prefix: string;
+          sortorder?: string;
+          sortcolumn?: string;
+          search?: string;
+          offsets?: number;
+          levels?: number;
+          limits?: number;
+          bucketname: string;
+        };
         Returns: {
-          metadata: Json
-          last_accessed_at: string
-          updated_at: string
-          id: string
-          name: string
-          created_at: string
-        }[]
-      }
+          metadata: Json;
+          last_accessed_at: string;
+          updated_at: string;
+          id: string;
+          name: string;
+          created_at: string;
+        }[];
+      };
       search_v1_optimised: {
         Args: {
-          offsets?: number
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
-          levels?: number
-          limits?: number
-          bucketname: string
-          prefix: string
-        }
+          offsets?: number;
+          search?: string;
+          sortcolumn?: string;
+          sortorder?: string;
+          levels?: number;
+          limits?: number;
+          bucketname: string;
+          prefix: string;
+        };
         Returns: {
-          metadata: Json
-          name: string
-          id: string
-          updated_at: string
-          created_at: string
-          last_accessed_at: string
-        }[]
-      }
+          metadata: Json;
+          name: string;
+          id: string;
+          updated_at: string;
+          created_at: string;
+          last_accessed_at: string;
+        }[];
+      };
       search_v2: {
         Args: {
-          prefix: string
-          bucket_name: string
-          limits?: number
-          levels?: number
-          start_after?: string
-        }
+          prefix: string;
+          bucket_name: string;
+          limits?: number;
+          levels?: number;
+          start_after?: string;
+        };
         Returns: {
-          key: string
-          name: string
-          id: string
-          updated_at: string
-          created_at: string
-          metadata: Json
-        }[]
-      }
-    }
+          key: string;
+          name: string;
+          id: string;
+          updated_at: string;
+          created_at: string;
+          metadata: Json;
+        }[];
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DefaultSchema = Database[Extract<keyof Database, "public">]
+type DefaultSchema = Database[Extract<keyof Database, 'public'>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        Database[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+  ? (Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      Database[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+  ? Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+  ? Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof Database },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof Database[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+  ? Database[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
 
 export const Constants = {
   graphql_public: {
@@ -7412,101 +7774,100 @@ export const Constants = {
   },
   public: {
     Enums: {
-      attachment_type: ["image", "document", "video", "audio", "other"],
+      attachment_type: ['image', 'document', 'video', 'audio', 'other'],
       audit_action_type: [
-        "login",
-        "logout",
-        "view_data",
-        "create_record",
-        "update_record",
-        "delete_record",
-        "export_data",
-        "import_data",
-        "maintenance_action",
-        "security_event",
-        "system_configuration",
+        'login',
+        'logout',
+        'view_data',
+        'create_record',
+        'update_record',
+        'delete_record',
+        'export_data',
+        'import_data',
+        'maintenance_action',
+        'security_event',
+        'system_configuration',
       ],
-      backup_code_status: ["active", "used", "expired"],
-      conversation_type: ["direct", "group"],
+      backup_code_status: ['active', 'used', 'expired'],
+      conversation_type: ['direct', 'group'],
       file_category: [
-        "preparation",
-        "notes",
-        "recording",
-        "resource",
-        "personal",
-        "avatar",
-        "document",
+        'preparation',
+        'notes',
+        'recording',
+        'resource',
+        'personal',
+        'avatar',
+        'document',
       ],
-      file_permission_type: ["view", "download", "edit"],
-      language: ["en", "he"],
+      file_permission_type: ['view', 'download', 'edit'],
+      language: ['en', 'he'],
       maintenance_action_type: [
-        "backup_database",
-        "database_health_check",
-        "clear_cache",
-        "get_cache_stats",
-        "export_logs",
-        "cleanup_logs",
-        "clean_temp_files",
-        "system_cleanup",
-        "update_configuration",
-        "restart_services",
+        'backup_database',
+        'database_health_check',
+        'clear_cache',
+        'get_cache_stats',
+        'export_logs',
+        'cleanup_logs',
+        'clean_temp_files',
+        'system_cleanup',
+        'update_configuration',
+        'restart_services',
       ],
       maintenance_status: [
-        "started",
-        "in_progress",
-        "completed",
-        "failed",
-        "partial",
-        "cancelled",
-        "timeout",
+        'started',
+        'in_progress',
+        'completed',
+        'failed',
+        'partial',
+        'cancelled',
+        'timeout',
       ],
-      message_status: ["sent", "delivered", "read"],
-      message_type: ["text", "file", "system"],
+      message_status: ['sent', 'delivered', 'read'],
+      message_type: ['text', 'file', 'system'],
       mfa_event_type: [
-        "setup",
-        "enable",
-        "disable",
-        "verify_success",
-        "verify_failure",
-        "backup_code_used",
-        "backup_codes_regenerated",
+        'setup',
+        'enable',
+        'disable',
+        'verify_success',
+        'verify_failure',
+        'backup_code_used',
+        'backup_codes_regenerated',
       ],
-      mfa_method: ["totp", "backup_code"],
-      mfa_method_type: ["totp", "sms", "email", "webauthn"],
-      mfa_status: ["pending", "active", "disabled", "suspended"],
-      mfa_verification_status: ["success", "failed", "expired", "rate_limited"],
+      mfa_method: ['totp', 'backup_code'],
+      mfa_method_type: ['totp', 'sms', 'email', 'webauthn'],
+      mfa_status: ['pending', 'active', 'disabled', 'suspended'],
+      mfa_verification_status: ['success', 'failed', 'expired', 'rate_limited'],
       notification_type: [
-        "session_reminder",
-        "session_confirmation",
-        "new_message",
-        "system_update",
-        "welcome_message",
-        "goal_achieved",
-        "appointment_reminder",
-        "coach_message",
-        "client_message",
-        "session_cancelled",
-        "session_rescheduled",
-        "reflection_reminder",
-        "system_announcement",
-        "payment_reminder",
+        'session_reminder',
+        'session_confirmation',
+        'new_message',
+        'system_update',
+        'welcome_message',
+        'goal_achieved',
+        'appointment_reminder',
+        'coach_message',
+        'client_message',
+        'session_cancelled',
+        'session_rescheduled',
+        'reflection_reminder',
+        'system_announcement',
+        'payment_reminder',
       ],
-      privacy_level: ["private", "shared_with_client"],
-      security_severity: ["low", "medium", "high", "critical"],
+      privacy_level: ['private', 'shared_with_client'],
+      security_severity: ['low', 'medium', 'high', 'critical'],
       session_status: [
-        "scheduled",
-        "in_progress",
-        "completed",
-        "cancelled",
-        "rescheduled",
-        "no_show",
+        'scheduled',
+        'in_progress',
+        'completed',
+        'cancelled',
+        'rescheduled',
+        'no_show',
       ],
-      user_role: ["client", "coach", "admin"],
-      user_status: ["active", "inactive", "suspended"],
+      user_role: ['client', 'coach', 'admin'],
+      user_status: ['active', 'inactive', 'suspended'],
     },
   },
   storage: {
     Enums: {},
   },
-} as const
-
+} as const;

--- a/supabase/migrations/20251001000000_add_tasks_domain.sql
+++ b/supabase/migrations/20251001000000_add_tasks_domain.sql
@@ -1,0 +1,273 @@
+-- Task domain schema for Supabase
+-- Date: 2025-10-01
+-- Creates enums and tables powering the Action Items & Homework feature set
+
+-- Enum definitions ---------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'task_priority'
+  ) THEN
+    CREATE TYPE task_priority AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'task_status'
+  ) THEN
+    CREATE TYPE task_status AS ENUM (
+      'PENDING',
+      'IN_PROGRESS',
+      'COMPLETED',
+      'OVERDUE'
+    );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'task_notification_type'
+  ) THEN
+    CREATE TYPE task_notification_type AS ENUM (
+      'ASSIGNMENT_CREATED',
+      'UPCOMING_DUE',
+      'OVERDUE',
+      'RECURRING_PROMPT'
+    );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'task_notification_status'
+  ) THEN
+    CREATE TYPE task_notification_status AS ENUM (
+      'SCHEDULED',
+      'PROCESSING',
+      'SENT',
+      'FAILED',
+      'CANCELLED'
+    );
+  END IF;
+END
+$$;
+
+-- Utility trigger ---------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.handle_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = TIMEZONE('utc', NOW());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Task categories ---------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  coach_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  color_hex TEXT DEFAULT '#1D7A85',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW())
+);
+
+CREATE TRIGGER task_categories_set_updated_at
+BEFORE UPDATE ON public.task_categories
+FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- Tasks -------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  coach_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  client_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  category_id UUID REFERENCES public.task_categories(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  priority task_priority NOT NULL DEFAULT 'MEDIUM',
+  status task_status NOT NULL DEFAULT 'PENDING',
+  visibility_to_coach BOOLEAN NOT NULL DEFAULT TRUE,
+  due_date TIMESTAMPTZ,
+  recurrence_rule JSONB,
+  archived_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW())
+);
+
+CREATE TRIGGER tasks_set_updated_at
+BEFORE UPDATE ON public.tasks
+FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- Task instances ----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_instances (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_id UUID NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+  scheduled_date TIMESTAMPTZ,
+  due_date TIMESTAMPTZ NOT NULL,
+  status task_status NOT NULL DEFAULT 'PENDING',
+  completion_percentage INTEGER NOT NULL DEFAULT 0 CHECK (completion_percentage BETWEEN 0 AND 100),
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW())
+);
+
+CREATE TRIGGER task_instances_set_updated_at
+BEFORE UPDATE ON public.task_instances
+FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- Progress updates --------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_progress_updates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_instance_id UUID NOT NULL REFERENCES public.task_instances(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  percentage INTEGER NOT NULL CHECK (percentage BETWEEN 0 AND 100),
+  note TEXT,
+  is_visible_to_coach BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW())
+);
+
+-- Attachments -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_attachments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_instance_id UUID REFERENCES public.task_instances(id) ON DELETE CASCADE,
+  progress_update_id UUID REFERENCES public.task_progress_updates(id) ON DELETE CASCADE,
+  file_url TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  file_size BIGINT NOT NULL CHECK (file_size >= 0),
+  mime_type TEXT,
+  uploaded_by_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW())
+);
+
+-- Notification jobs -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_notification_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_instance_id UUID NOT NULL REFERENCES public.task_instances(id) ON DELETE CASCADE,
+  type task_notification_type NOT NULL,
+  status task_notification_status NOT NULL DEFAULT 'SCHEDULED',
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  sent_at TIMESTAMPTZ,
+  payload JSONB NOT NULL DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW())
+);
+
+CREATE TRIGGER task_notification_jobs_set_updated_at
+BEFORE UPDATE ON public.task_notification_jobs
+FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- Export logs -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_export_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  coach_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  client_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT TIMEZONE('utc', NOW()),
+  file_url TEXT NOT NULL,
+  filters JSONB NOT NULL DEFAULT '{}'::JSONB
+);
+
+-- Indexes -----------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_task_categories_coach_id ON public.task_categories (coach_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_coach_client ON public.tasks (coach_id, client_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_client_due_date ON public.tasks (client_id, due_date);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON public.tasks (status);
+CREATE INDEX IF NOT EXISTS idx_task_instances_task_due_date ON public.task_instances (task_id, due_date);
+CREATE INDEX IF NOT EXISTS idx_task_instances_status ON public.task_instances (status);
+CREATE INDEX IF NOT EXISTS idx_task_progress_updates_instance ON public.task_progress_updates (task_instance_id);
+CREATE INDEX IF NOT EXISTS idx_task_attachments_instance ON public.task_attachments (task_instance_id);
+CREATE INDEX IF NOT EXISTS idx_task_notification_jobs_status ON public.task_notification_jobs (status);
+CREATE INDEX IF NOT EXISTS idx_task_notification_jobs_scheduled_at ON public.task_notification_jobs (scheduled_at);
+CREATE INDEX IF NOT EXISTS idx_task_export_logs_coach_client ON public.task_export_logs (coach_id, client_id);
+
+-- Row level security ------------------------------------------------------
+ALTER TABLE public.task_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_instances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_progress_updates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_attachments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_notification_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_export_logs ENABLE ROW LEVEL SECURITY;
+
+-- Basic policies allow service role access; detailed policies will follow in later steps
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'tasks' AND policyname = 'tasks_service_role'
+  ) THEN
+    CREATE POLICY tasks_service_role ON public.tasks
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'task_categories' AND policyname = 'task_categories_service_role'
+  ) THEN
+    CREATE POLICY task_categories_service_role ON public.task_categories
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'task_instances' AND policyname = 'task_instances_service_role'
+  ) THEN
+    CREATE POLICY task_instances_service_role ON public.task_instances
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'task_progress_updates' AND policyname = 'task_progress_updates_service_role'
+  ) THEN
+    CREATE POLICY task_progress_updates_service_role ON public.task_progress_updates
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'task_attachments' AND policyname = 'task_attachments_service_role'
+  ) THEN
+    CREATE POLICY task_attachments_service_role ON public.task_attachments
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'task_notification_jobs' AND policyname = 'task_notification_jobs_service_role'
+  ) THEN
+    CREATE POLICY task_notification_jobs_service_role ON public.task_notification_jobs
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'task_export_logs' AND policyname = 'task_export_logs_service_role'
+  ) THEN
+    CREATE POLICY task_export_logs_service_role ON public.task_export_logs
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END
+$$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -74,6 +74,207 @@ WHERE s.status = 'completed' AND s.coach_id = '00000000-0000-0000-0000-000000000
 LIMIT 2
 ON CONFLICT (id) DO NOTHING;
 
+-- Insert sample task categories
+INSERT INTO public.task_categories (id, coach_id, label, color_hex)
+VALUES
+  ('11111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000001', 'Accountability', '#1D7A85'),
+  ('22222222-2222-2222-2222-222222222222', '00000000-0000-0000-0000-000000000001', 'Wellness', '#4FA3C4')
+ON CONFLICT (id) DO UPDATE SET
+  coach_id = EXCLUDED.coach_id,
+  label = EXCLUDED.label,
+  color_hex = EXCLUDED.color_hex;
+
+-- Insert sample tasks
+INSERT INTO public.tasks (
+  id,
+  coach_id,
+  client_id,
+  category_id,
+  title,
+  description,
+  priority,
+  status,
+  visibility_to_coach,
+  due_date,
+  recurrence_rule,
+  archived_at
+)
+VALUES
+  (
+    'aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000002',
+    '11111111-1111-1111-1111-111111111111',
+    'Complete reflection worksheet',
+    'Finish the weekly reflection worksheet and share highlights before the next session.',
+    'MEDIUM',
+    'IN_PROGRESS',
+    true,
+    NOW() + INTERVAL '2 days',
+    NULL,
+    NULL
+  ),
+  (
+    'bbbbbbb2-bbbb-bbbb-bbbb-bbbbbbbbbbb2',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000003',
+    '22222222-2222-2222-2222-222222222222',
+    'Daily mindfulness practice',
+    'Spend 10 minutes each morning practicing guided breathing. Mark progress every few days.',
+    'HIGH',
+    'PENDING',
+    true,
+    NOW() + INTERVAL '1 day',
+    '{"frequency":"DAILY","interval":1,"startDate":"' || TO_CHAR(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS".000Z"') || '","rrule":"FREQ=DAILY"}'::jsonb,
+    NULL
+  )
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  description = EXCLUDED.description,
+  priority = EXCLUDED.priority,
+  status = EXCLUDED.status,
+  visibility_to_coach = EXCLUDED.visibility_to_coach,
+  due_date = EXCLUDED.due_date,
+  recurrence_rule = EXCLUDED.recurrence_rule;
+
+-- Insert sample task instances
+INSERT INTO public.task_instances (
+  id,
+  task_id,
+  scheduled_date,
+  due_date,
+  status,
+  completion_percentage,
+  completed_at
+)
+VALUES
+  (
+    'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaa1111',
+    'aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1',
+    NOW() - INTERVAL '1 day',
+    NOW() + INTERVAL '2 days',
+    'IN_PROGRESS',
+    40,
+    NULL
+  ),
+  (
+    'bbbb2222-bbbb-bbbb-bbbb-bbbbbbbb2222',
+    'bbbbbbb2-bbbb-bbbb-bbbb-bbbbbbbbbbb2',
+    NOW(),
+    NOW() + INTERVAL '1 day',
+    'PENDING',
+    0,
+    NULL
+  ),
+  (
+    'bbbb3333-bbbb-bbbb-bbbb-bbbbbbbb3333',
+    'bbbbbbb2-bbbb-bbbb-bbbb-bbbbbbbbbbb2',
+    NOW() + INTERVAL '1 day',
+    NOW() + INTERVAL '2 days',
+    'PENDING',
+    0,
+    NULL
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- Insert sample progress update
+INSERT INTO public.task_progress_updates (
+  id,
+  task_instance_id,
+  author_id,
+  percentage,
+  note,
+  is_visible_to_coach
+)
+VALUES
+  (
+    'cccc4444-cccc-cccc-cccc-cccccccc4444',
+    'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaa1111',
+    '00000000-0000-0000-0000-000000000002',
+    40,
+    'Completed the first section of the worksheet and drafted answers for the second.',
+    true
+  )
+ON CONFLICT (id) DO UPDATE SET
+  percentage = EXCLUDED.percentage,
+  note = EXCLUDED.note,
+  is_visible_to_coach = EXCLUDED.is_visible_to_coach;
+
+-- Insert sample attachment metadata
+INSERT INTO public.task_attachments (
+  id,
+  task_instance_id,
+  progress_update_id,
+  file_url,
+  file_name,
+  file_size,
+  mime_type,
+  uploaded_by_id
+)
+VALUES
+  (
+    'dddd5555-dddd-dddd-dddd-dddddddd5555',
+    'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaa1111',
+    'cccc4444-cccc-cccc-cccc-cccccccc4444',
+    'https://files.example.com/tasks/reflection-notes.pdf',
+    'reflection-notes.pdf',
+    204800,
+    'application/pdf',
+    '00000000-0000-0000-0000-000000000002'
+  )
+ON CONFLICT (id) DO UPDATE SET
+  file_url = EXCLUDED.file_url,
+  file_name = EXCLUDED.file_name,
+  file_size = EXCLUDED.file_size,
+  mime_type = EXCLUDED.mime_type;
+
+-- Insert sample notification job
+INSERT INTO public.task_notification_jobs (
+  id,
+  task_instance_id,
+  type,
+  status,
+  scheduled_at,
+  sent_at,
+  payload
+)
+VALUES
+  (
+    'eeee6666-eeee-eeee-eeee-eeeeeeee6666',
+    'bbbb2222-bbbb-bbbb-bbbb-bbbbbbbb2222',
+    'UPCOMING_DUE',
+    'SCHEDULED',
+    NOW() + INTERVAL '12 hours',
+    NULL,
+    '{"message":"Reminder: Mindfulness practice is due tomorrow"}'::jsonb
+  )
+ON CONFLICT (id) DO UPDATE SET
+  scheduled_at = EXCLUDED.scheduled_at,
+  payload = EXCLUDED.payload;
+
+-- Insert sample export log
+INSERT INTO public.task_export_logs (
+  id,
+  coach_id,
+  client_id,
+  generated_at,
+  file_url,
+  filters
+)
+VALUES
+  (
+    'ffff7777-ffff-ffff-ffff-ffffffff7777',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000002',
+    NOW() - INTERVAL '1 day',
+    'https://files.example.com/exports/client-task-summary.pdf',
+    '{"range":{"from":"2025-01-01","to":"2025-02-01"}}'::jsonb
+  )
+ON CONFLICT (id) DO UPDATE SET
+  generated_at = EXCLUDED.generated_at,
+  file_url = EXCLUDED.file_url,
+  filters = EXCLUDED.filters;
+
 -- Update last_seen_at for active users
 UPDATE public.users
 SET last_seen_at = NOW()

--- a/tests/api/progress.test.ts
+++ b/tests/api/progress.test.ts
@@ -1,0 +1,446 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clientId = '4c0c5d6e-7f8a-4b1c-9d2e-abcdefabcdef';
+const taskId = 'b1e4d6c7-2f3a-4a5b-8c9d-0123456789ab';
+const instanceId = 'c2d3e4f5-6789-4abc-def0-1234567890ab';
+
+type TestUser = {
+  id: string;
+  email: string;
+  role: 'coach' | 'client' | 'admin';
+  status: string;
+};
+
+let currentUser: TestUser = {
+  id: clientId,
+  email: 'client@example.com',
+  role: 'client',
+  status: 'active',
+};
+
+const hoisted = vi.hoisted(() => {
+  const HTTP_STATUS = {
+    OK: 200,
+    CREATED: 201,
+    BAD_REQUEST: 400,
+    UNAUTHORIZED: 401,
+    FORBIDDEN: 403,
+    INTERNAL_SERVER_ERROR: 500,
+  } as const;
+
+  const mockProgressService = {
+    createProgressUpdate: vi.fn(),
+  };
+
+  const mockCreateSuccessResponse = vi.fn(
+    (data, message = 'Success', status = HTTP_STATUS.OK) =>
+      new Response(JSON.stringify({ success: true, data, message }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+  );
+
+  const mockCreateErrorResponse = vi.fn(
+    (error, status = HTTP_STATUS.BAD_REQUEST) => {
+      const message =
+        typeof error === 'string' ? error : (error?.message ?? 'Error');
+      return new Response(JSON.stringify({ success: false, error: message }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  );
+
+  const mockValidateRequestBody = vi.fn();
+
+  const mockGetUser = vi.fn();
+  const mockSingle = vi.fn();
+  const mockEq = vi.fn(() => ({ single: mockSingle }));
+  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+  const mockFrom = vi.fn(() => ({ select: mockSelect }));
+
+  const mockCreateSignedUploadUrl = vi.fn();
+  const mockGetPublicUrl = vi.fn();
+  const mockStorageFrom = vi.fn(() => ({
+    createSignedUploadUrl: mockCreateSignedUploadUrl,
+    getPublicUrl: mockGetPublicUrl,
+  }));
+
+  const mockSupabaseClient = {
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  } as const;
+
+  const mockAdminClient = {
+    storage: {
+      from: mockStorageFrom,
+    },
+  } as const;
+
+  return {
+    HTTP_STATUS,
+    mockProgressService,
+    mockCreateSuccessResponse,
+    mockCreateErrorResponse,
+    mockValidateRequestBody,
+    mockGetUser,
+    mockSingle,
+    mockEq,
+    mockSelect,
+    mockFrom,
+    mockCreateSignedUploadUrl,
+    mockGetPublicUrl,
+    mockStorageFrom,
+    mockSupabaseClient,
+    mockAdminClient,
+  };
+});
+
+vi.mock('@/modules/tasks/services/progress-service', () => ({
+  ProgressService: vi.fn(() => hoisted.mockProgressService),
+  ProgressServiceError: class MockProgressServiceError extends Error {
+    status: number;
+    constructor(
+      message: string,
+      status = hoisted.HTTP_STATUS.INTERNAL_SERVER_ERROR
+    ) {
+      super(message);
+      this.status = status;
+      this.name = 'ProgressServiceError';
+    }
+  },
+}));
+
+vi.mock('@/lib/api/utils', () => ({
+  HTTP_STATUS: hoisted.HTTP_STATUS,
+  createErrorResponse: hoisted.mockCreateErrorResponse,
+  createSuccessResponse: hoisted.mockCreateSuccessResponse,
+  validateRequestBody: hoisted.mockValidateRequestBody,
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerClient: vi.fn(() => hoisted.mockSupabaseClient),
+  createAdminClient: vi.fn(() => hoisted.mockAdminClient),
+}));
+
+const {
+  HTTP_STATUS,
+  mockProgressService,
+  mockCreateSuccessResponse,
+  mockCreateErrorResponse,
+  mockValidateRequestBody,
+  mockGetUser,
+  mockSingle,
+  mockSelect,
+  mockEq,
+  mockFrom,
+  mockCreateSignedUploadUrl,
+  mockGetPublicUrl,
+  mockStorageFrom,
+} = hoisted;
+
+import { POST as signAttachment } from '@/app/api/attachments/sign/route';
+import { POST as createProgressUpdate } from '@/app/api/tasks/[taskId]/instances/[instanceId]/progress/route';
+import { ProgressServiceError } from '@/modules/tasks/services/progress-service';
+
+const createNextRequest = (url: string, init?: RequestInit) =>
+  new NextRequest(new Request(url, init));
+
+describe('Task progress API routes', () => {
+  beforeEach(() => {
+    Object.values(mockProgressService).forEach(fn => fn.mockReset());
+    mockCreateSuccessResponse.mockClear();
+    mockCreateErrorResponse.mockClear();
+    mockValidateRequestBody.mockReset();
+
+    mockGetUser.mockReset();
+    mockSingle.mockReset();
+    mockSelect.mockReset();
+    mockEq.mockReset();
+    mockFrom.mockReset();
+
+    mockCreateSignedUploadUrl.mockReset();
+    mockGetPublicUrl.mockReset();
+    mockStorageFrom.mockReset();
+    mockStorageFrom.mockImplementation(() => ({
+      createSignedUploadUrl: mockCreateSignedUploadUrl,
+      getPublicUrl: mockGetPublicUrl,
+    }));
+
+    currentUser = {
+      id: clientId,
+      email: 'client@example.com',
+      role: 'client',
+      status: 'active',
+    };
+
+    mockGetUser.mockImplementation(async () => ({
+      data: { user: { id: currentUser.id, role: currentUser.role } },
+      error: null,
+    }));
+    mockSingle.mockImplementation(async () => ({
+      data: { role: currentUser.role },
+      error: null,
+    }));
+    mockEq.mockImplementation(() => ({ single: mockSingle }));
+    mockSelect.mockImplementation(() => ({ eq: mockEq }));
+    mockFrom.mockImplementation(() => ({ select: mockSelect }));
+  });
+
+  describe('POST /api/tasks/[taskId]/instances/[instanceId]/progress', () => {
+    it('creates a progress update for the authenticated client', async () => {
+      const progressDto = {
+        id: 'progress-123',
+        taskId,
+        taskInstanceId: instanceId,
+        authorId: clientId,
+        percentage: 80,
+        note: 'Made good progress today',
+        isVisibleToCoach: true,
+        createdAt: new Date().toISOString(),
+        instanceStatus: 'IN_PROGRESS',
+        completionPercentage: 80,
+        completedAt: null,
+        attachments: [],
+      };
+
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: {
+          percentage: 80,
+          note: 'Made good progress today',
+          isVisibleToCoach: true,
+        },
+      });
+
+      mockProgressService.createProgressUpdate.mockResolvedValue(progressDto);
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}/instances/${instanceId}/progress`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await createProgressUpdate(request, {
+        params: Promise.resolve({ taskId, instanceId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.CREATED);
+      expect(mockProgressService.createProgressUpdate).toHaveBeenCalledWith(
+        { id: currentUser.id, role: 'client' },
+        {
+          taskId,
+          taskInstanceId: instanceId,
+          input: expect.objectContaining({ percentage: 80 }),
+        }
+      );
+      expect(payload.data).toEqual(progressDto);
+    });
+
+    it('returns validation errors when the payload is invalid', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: false,
+        error: { message: 'Validation failed' },
+      });
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}/instances/${instanceId}/progress`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await createProgressUpdate(request, {
+        params: Promise.resolve({ taskId, instanceId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.BAD_REQUEST);
+      expect(payload.success).toBe(false);
+      expect(mockProgressService.createProgressUpdate).not.toHaveBeenCalled();
+    });
+
+    it('maps service errors to API responses', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: { percentage: 50 },
+      });
+
+      mockProgressService.createProgressUpdate.mockRejectedValue(
+        new ProgressServiceError('Access denied', HTTP_STATUS.FORBIDDEN)
+      );
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}/instances/${instanceId}/progress`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await createProgressUpdate(request, {
+        params: Promise.resolve({ taskId, instanceId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+      expect(payload.error).toBe('Access denied');
+    });
+
+    it('returns unauthorized when no Supabase session exists', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not signed in' },
+      });
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}/instances/${instanceId}/progress`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await createProgressUpdate(request, {
+        params: Promise.resolve({ taskId, instanceId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.UNAUTHORIZED);
+      expect(payload.success).toBe(false);
+      expect(mockProgressService.createProgressUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/attachments/sign', () => {
+    it('returns signed upload details for an authenticated user', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: {
+          fileName: ' Progress Report .pdf ',
+          fileSize: 1024,
+          contentType: 'application/pdf',
+        },
+      });
+
+      mockCreateSignedUploadUrl.mockResolvedValue({
+        data: {
+          signedUrl: 'https://upload.example.com',
+          token: 'token-123',
+          path: 'path/from/supabase',
+        },
+        error: null,
+      });
+
+      mockGetPublicUrl.mockReturnValue({
+        data: { publicUrl: 'https://public.example.com/file.pdf' },
+      });
+
+      const request = createNextRequest(
+        'http://localhost/api/attachments/sign',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await signAttachment(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.CREATED);
+      expect(payload.data.uploadUrl).toBe('https://upload.example.com');
+      expect(payload.data.fileName).toBe('progress-report.pdf');
+      expect(mockCreateSignedUploadUrl).toHaveBeenCalledWith(
+        expect.stringMatching(`${currentUser.id}/`),
+        expect.objectContaining({ upsert: false })
+      );
+    });
+
+    it('returns validation errors when signing payload fails validation', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: false,
+        error: { message: 'Validation failed' },
+      });
+
+      const request = createNextRequest(
+        'http://localhost/api/attachments/sign',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await signAttachment(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.BAD_REQUEST);
+      expect(payload.success).toBe(false);
+      expect(mockCreateSignedUploadUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns unauthorized when no session is present', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not signed in' },
+      });
+
+      const request = createNextRequest(
+        'http://localhost/api/attachments/sign',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await signAttachment(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.UNAUTHORIZED);
+      expect(payload.success).toBe(false);
+      expect(mockCreateSignedUploadUrl).not.toHaveBeenCalled();
+    });
+
+    it('handles storage errors gracefully', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: {
+          fileName: 'progress.pdf',
+          fileSize: 1024,
+          contentType: 'application/pdf',
+        },
+      });
+
+      mockCreateSignedUploadUrl.mockResolvedValue({
+        data: null,
+        error: { message: 'storage failure' },
+      });
+
+      const request = createNextRequest(
+        'http://localhost/api/attachments/sign',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await signAttachment(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      expect(payload.success).toBe(false);
+    });
+  });
+});

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -1,0 +1,484 @@
+import { NextRequest } from 'next/server';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const coachId = '8d8b9b1d-9a9e-4d7a-84fd-1234567890ab';
+const clientId = '4c0c5d6e-7f8a-4b1c-9d2e-abcdefabcdef';
+const taskId = 'b1e4d6c7-2f3a-4a5b-8c9d-0123456789ab';
+
+type TestUser = {
+  id: string;
+  email: string;
+  role: 'coach' | 'admin' | 'client';
+  status: string;
+};
+
+let currentUser: TestUser = {
+  id: coachId,
+  email: 'coach@example.com',
+  role: 'coach',
+  status: 'active',
+};
+
+const hoisted = vi.hoisted(() => {
+  const HTTP_STATUS = {
+    OK: 200,
+    CREATED: 201,
+    BAD_REQUEST: 400,
+    FORBIDDEN: 403,
+    NOT_FOUND: 404,
+    INTERNAL_SERVER_ERROR: 500,
+  } as const;
+
+  const mockTaskService = {
+    createTask: vi.fn(),
+    listTasks: vi.fn(),
+    getTaskById: vi.fn(),
+    updateTask: vi.fn(),
+  };
+
+  const mockCreateSuccessResponse = vi.fn(
+    (data, message = 'Success', status = HTTP_STATUS.OK) =>
+      new Response(JSON.stringify({ success: true, data, message }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+  );
+
+  const mockCreateErrorResponse = vi.fn(
+    (error, status = HTTP_STATUS.BAD_REQUEST) => {
+      const message =
+        typeof error === 'string' ? error : (error?.message ?? 'Error');
+      return new Response(JSON.stringify({ success: false, error: message }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  );
+
+  const mockValidateRequestBody = vi.fn();
+
+  const mockRequireRole = vi.fn((role: string) => {
+    return (
+        handler: (
+          user: typeof currentUser,
+          request: NextRequest,
+          ...rest: unknown[]
+        ) => Promise<unknown>
+      ) =>
+      async (
+        user: typeof currentUser,
+        request: NextRequest,
+        ...rest: unknown[]
+      ) => {
+        if (role === 'coach' && !['coach', 'admin'].includes(user.role)) {
+          return mockCreateErrorResponse(
+            `Access denied. Required role: ${role}`,
+            HTTP_STATUS.FORBIDDEN
+          );
+        }
+        return handler(user, request, ...rest);
+      };
+  });
+
+  const mockRequireAuth = vi.fn(
+    (
+      handler: (
+        user: typeof currentUser,
+        request: NextRequest,
+        ...rest: unknown[]
+      ) => Promise<unknown>
+    ) =>
+      (request: NextRequest, ...rest: unknown[]) =>
+        handler(currentUser, request, ...rest)
+  );
+
+  const mockWithErrorHandling = vi.fn(
+    (handler: (request: NextRequest, ...rest: unknown[]) => Promise<unknown>) =>
+      handler
+  );
+
+  const mockGetUser = vi.fn();
+  const mockSingle = vi.fn();
+  const mockEq = vi.fn(() => ({ single: mockSingle }));
+  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+  const mockFrom = vi.fn(() => ({ select: mockSelect }));
+
+  const mockSupabaseClient = {
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  } as const;
+
+  return {
+    HTTP_STATUS,
+    mockTaskService,
+    mockCreateSuccessResponse,
+    mockCreateErrorResponse,
+    mockValidateRequestBody,
+    mockRequireRole,
+    mockRequireAuth,
+    mockWithErrorHandling,
+    mockSupabaseClient,
+    mockGetUser,
+    mockSingle,
+    mockSelect,
+    mockEq,
+  };
+});
+
+vi.mock('@/modules/tasks/services/task-service', () => ({
+  TaskService: vi.fn(() => hoisted.mockTaskService),
+  TaskServiceError: class MockTaskServiceError extends Error {
+    status: number;
+    constructor(
+      message: string,
+      status = hoisted.HTTP_STATUS.INTERNAL_SERVER_ERROR
+    ) {
+      super(message);
+      this.status = status;
+      this.name = 'TaskServiceError';
+    }
+  },
+}));
+
+vi.mock('@/lib/api/utils', () => ({
+  HTTP_STATUS: hoisted.HTTP_STATUS,
+  createSuccessResponse: hoisted.mockCreateSuccessResponse,
+  createErrorResponse: hoisted.mockCreateErrorResponse,
+  validateRequestBody: hoisted.mockValidateRequestBody,
+  requireRole: hoisted.mockRequireRole,
+  requireAuth: hoisted.mockRequireAuth,
+  withErrorHandling: hoisted.mockWithErrorHandling,
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerClient: vi.fn(() => hoisted.mockSupabaseClient),
+}));
+
+const {
+  HTTP_STATUS,
+  mockTaskService,
+  mockCreateSuccessResponse,
+  mockCreateErrorResponse,
+  mockValidateRequestBody,
+  mockRequireRole,
+  mockRequireAuth,
+  mockWithErrorHandling,
+  mockGetUser,
+  mockSingle,
+  mockSelect,
+  mockEq,
+} = hoisted;
+
+import { GET as GET_TASK, PATCH } from '@/app/api/tasks/[taskId]/route';
+import { POST, GET } from '@/app/api/tasks/route';
+import { TaskServiceError } from '@/modules/tasks/services/task-service';
+
+const createNextRequest = (url: string, init?: RequestInit) =>
+  new NextRequest(new Request(url, init));
+
+describe('Task API routes', () => {
+  const sampleTask = {
+    id: taskId,
+    coachId: coachId,
+    clientId: clientId,
+    category: null,
+    title: 'Complete worksheet',
+    description: 'Finish the weekly reflection worksheet.',
+    priority: 'MEDIUM',
+    visibilityToCoach: true,
+    dueDate: new Date().toISOString(),
+    recurrenceRule: null,
+    archivedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    instances: [],
+  };
+
+  const listResponse = {
+    data: [sampleTask],
+    pagination: {
+      page: 1,
+      pageSize: 20,
+      total: 1,
+      totalPages: 1,
+    },
+  };
+
+  beforeEach(() => {
+    Object.values(mockTaskService).forEach(fn => fn.mockReset());
+    mockCreateSuccessResponse.mockClear();
+    mockCreateErrorResponse.mockClear();
+    mockValidateRequestBody.mockReset();
+    mockRequireRole.mockClear();
+    mockRequireAuth.mockClear();
+    mockWithErrorHandling.mockClear();
+
+    mockGetUser.mockReset();
+    mockSingle.mockReset();
+    mockSelect.mockReset();
+    mockEq.mockReset();
+
+    currentUser = {
+      id: coachId,
+      email: 'coach@example.com',
+      role: 'coach',
+      status: 'active',
+    };
+
+    mockGetUser.mockImplementation(async () => ({
+      data: { user: { id: currentUser.id } },
+      error: null,
+    }));
+    mockSingle.mockImplementation(async () => ({
+      data: { role: currentUser.role },
+      error: null,
+    }));
+    mockEq.mockImplementation(() => ({ single: mockSingle }));
+    mockSelect.mockImplementation(() => ({ eq: mockEq }));
+  });
+
+  describe('POST /api/tasks', () => {
+    it('creates a task for the authenticated coach', async () => {
+      const dueDate = new Date();
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: {
+          title: 'Task title',
+          clientId,
+          dueDate,
+        },
+      });
+      mockTaskService.createTask.mockResolvedValue(sampleTask);
+
+      const request = createNextRequest('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      const response = await POST(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.CREATED);
+      expect(mockTaskService.createTask).toHaveBeenCalledWith(
+        { id: currentUser.id, role: 'coach' },
+        expect.objectContaining({ coachId: currentUser.id, clientId })
+      );
+      expect(payload.data).toEqual(sampleTask);
+    });
+
+    it('returns validation errors from the request body', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: false,
+        error: { message: 'Validation failed' },
+      });
+
+      const request = createNextRequest('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      const response = await POST(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.BAD_REQUEST);
+      expect(payload.success).toBe(false);
+      expect(mockTaskService.createTask).not.toHaveBeenCalled();
+    });
+
+    it('maps service errors to API responses', async () => {
+      const dueDate = new Date();
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: {
+          title: 'Task title',
+          clientId,
+          dueDate,
+        },
+      });
+      mockTaskService.createTask.mockRejectedValue(
+        new TaskServiceError('Access denied', HTTP_STATUS.FORBIDDEN)
+      );
+
+      const request = createNextRequest('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      const response = await POST(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+      expect(payload.success).toBe(false);
+      expect(payload.error).toBe('Access denied');
+    });
+  });
+
+  describe('GET /api/tasks', () => {
+    it('returns paginated tasks for the coach', async () => {
+      mockTaskService.listTasks.mockResolvedValue(listResponse);
+
+      const request = createNextRequest(
+        'http://localhost/api/tasks?page=1&pageSize=20',
+        {
+          method: 'GET',
+        }
+      );
+
+      const response = await GET(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskService.listTasks).toHaveBeenCalledWith(
+        { id: currentUser.id, role: 'coach' },
+        expect.objectContaining({ coachId: currentUser.id })
+      );
+      expect(payload.data).toEqual(listResponse);
+    });
+
+    it('prevents clients from accessing the coach list endpoint', async () => {
+      currentUser = { ...currentUser, id: clientId, role: 'client' };
+      const request = createNextRequest('http://localhost/api/tasks', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+      expect(payload.success).toBe(false);
+      expect(mockTaskService.listTasks).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/tasks/[taskId]', () => {
+    it('returns the task for an authorized client', async () => {
+      currentUser = { ...currentUser, id: clientId, role: 'client' };
+      mockTaskService.getTaskById.mockResolvedValue(sampleTask);
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}`,
+        { method: 'GET' }
+      );
+      const response = await GET_TASK(request, {
+        params: Promise.resolve({ taskId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskService.getTaskById).toHaveBeenCalledWith(taskId, {
+        id: clientId,
+        role: 'client',
+      });
+      expect(payload.data).toEqual(sampleTask);
+    });
+
+    it('propagates not found errors from the service', async () => {
+      mockTaskService.getTaskById.mockRejectedValue(
+        new TaskServiceError('Task not found', HTTP_STATUS.NOT_FOUND)
+      );
+
+      const missingTaskId = '6a6b6c6d-7e8f-4a1b-9c2d-abcdef123456';
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${missingTaskId}`,
+        { method: 'GET' }
+      );
+      const response = await GET_TASK(request, {
+        params: Promise.resolve({ taskId: missingTaskId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.NOT_FOUND);
+      expect(payload.error).toBe('Task not found');
+    });
+  });
+
+  describe('PATCH /api/tasks/[taskId]', () => {
+    it('updates a task for the coach', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: { title: 'Updated title' },
+      });
+      mockTaskService.updateTask.mockResolvedValue({
+        ...sampleTask,
+        title: 'Updated title',
+      });
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ taskId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskService.updateTask).toHaveBeenCalledWith(
+        taskId,
+        { id: currentUser.id, role: 'coach' },
+        { title: 'Updated title' }
+      );
+      expect(payload.data.title).toBe('Updated title');
+    });
+
+    it('returns validation errors when the payload is empty', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: false,
+        error: { message: 'At least one property must be provided' },
+      });
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ taskId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.BAD_REQUEST);
+      expect(payload.success).toBe(false);
+      expect(mockTaskService.updateTask).not.toHaveBeenCalled();
+    });
+
+    it('propagates service failures', async () => {
+      mockValidateRequestBody.mockReturnValue({
+        success: true,
+        data: { title: 'Updated title' },
+      });
+      mockTaskService.updateTask.mockRejectedValue(
+        new TaskServiceError('Access denied', HTTP_STATUS.FORBIDDEN)
+      );
+
+      const request = createNextRequest(
+        `http://localhost/api/tasks/${taskId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ taskId }),
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+      expect(payload.error).toBe('Access denied');
+    });
+  });
+});

--- a/tests/unit/recurrence-service.test.ts
+++ b/tests/unit/recurrence-service.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RecurrenceService,
+  RecurrenceServiceError,
+} from '@/modules/tasks/services/recurrence-service';
+
+describe('RecurrenceService', () => {
+  const baseDate = new Date('2025-02-10T12:00:00.000Z');
+
+  it('returns a single instance when no recurrence is provided', () => {
+    const service = new RecurrenceService();
+
+    const plan = service.planInstances({
+      dueDate: baseDate,
+    });
+
+    expect(plan.recurrenceRule).toBeNull();
+    expect(plan.instances).toHaveLength(1);
+    expect(plan.instances[0].dueDate.toISOString()).toBe(
+      '2025-02-10T12:00:00.000Z'
+    );
+    expect(plan.instances[0].scheduledDate.toISOString()).toBe(
+      '2025-02-10T12:00:00.000Z'
+    );
+  });
+
+  it('generates recurring instances based on the provided rule', () => {
+    const service = new RecurrenceService();
+
+    const plan = service.planInstances({
+      dueDate: baseDate,
+      recurrenceRule: {
+        frequency: 'WEEKLY',
+        interval: 1,
+        count: 3,
+        byWeekday: ['MO'],
+      },
+    });
+
+    expect(plan.instances).toHaveLength(3);
+    expect(
+      plan.instances.map(instance => instance.dueDate.toISOString())
+    ).toEqual([
+      '2025-02-10T12:00:00.000Z',
+      '2025-02-17T12:00:00.000Z',
+      '2025-02-24T12:00:00.000Z',
+    ]);
+    expect(plan.recurrenceRule?.rrule).toContain('FREQ=WEEKLY');
+  });
+
+  it('respects the service instance limit when no count/until is provided', () => {
+    const service = new RecurrenceService(2);
+
+    const plan = service.planInstances({
+      dueDate: baseDate,
+      recurrenceRule: {
+        frequency: 'DAILY',
+        interval: 1,
+      },
+    });
+
+    expect(plan.instances).toHaveLength(2);
+    expect(
+      plan.instances.map(instance => instance.dueDate.toISOString())
+    ).toEqual(['2025-02-10T12:00:00.000Z', '2025-02-11T12:00:00.000Z']);
+  });
+
+  it('throws when recurrence metadata is provided without a due date', () => {
+    const service = new RecurrenceService();
+
+    expect(() =>
+      service.planInstances({
+        dueDate: null,
+        recurrenceRule: {
+          frequency: 'DAILY',
+          interval: 1,
+        },
+      })
+    ).toThrow(RecurrenceServiceError);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,11 +31,38 @@ export default defineConfig({
   },
   resolve: {
     alias: [
-      { find: 'next-intl/middleware', replacement: path.resolve(__dirname, './src/test/mocks/next-intl-middleware.ts') },
-      { find: 'next-intl/routing', replacement: path.resolve(__dirname, './src/test/mocks/next-intl-routing.ts') },
-      { find: 'next-intl/navigation', replacement: path.resolve(__dirname, './src/test/mocks/next-intl-navigation.ts') },
-      { find: 'next-intl', replacement: path.resolve(__dirname, './src/test/mocks/next-intl.ts') },
-      { find: 'next/navigation', replacement: path.resolve(__dirname, './src/test/mocks/next-navigation.ts') },
+      {
+        find: 'next-intl/middleware',
+        replacement: path.resolve(
+          __dirname,
+          './src/test/mocks/next-intl-middleware.ts'
+        ),
+      },
+      {
+        find: 'next-intl/routing',
+        replacement: path.resolve(
+          __dirname,
+          './src/test/mocks/next-intl-routing.ts'
+        ),
+      },
+      {
+        find: 'next-intl/navigation',
+        replacement: path.resolve(
+          __dirname,
+          './src/test/mocks/next-intl-navigation.ts'
+        ),
+      },
+      {
+        find: 'next-intl',
+        replacement: path.resolve(__dirname, './src/test/mocks/next-intl.ts'),
+      },
+      {
+        find: 'next/navigation',
+        replacement: path.resolve(
+          __dirname,
+          './src/test/mocks/next-navigation.ts'
+        ),
+      },
       { find: '@', replacement: path.resolve(__dirname, './src') },
     ],
   },


### PR DESCRIPTION
## Summary
- add a Supabase-backed ProgressService, DTOs, and route handler so clients and coaches can submit task instance progress with attachments
- expose a signed upload endpoint for task attachments and document the storage bucket environment variable in the implementation plan and env example
- cover the new APIs with Vitest integration tests alongside updates to the shared environment module and task service barrel exports
- prevent the recurrence planner from inserting weekdays that occur before the task start date when multiple BYDAY values are provided

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres npx vitest run tests/unit/recurrence-service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e631b5e82c8320ac2813408476a31a