### PR TITLE
fix: preserve progress overdue state and use cookie-aware auth

### DIFF
--- a/src/app/api/tasks/[taskId]/instances/[instanceId]/progress/route.ts
+++ b/src/app/api/tasks/[taskId]/instances/[instanceId]/progress/route.ts
@@ -7,7 +7,7 @@ import {
   createSuccessResponse,
   validateRequestBody,
 } from '@/lib/api/utils';
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 import {
   ProgressService,
   ProgressServiceError,
@@ -44,7 +44,7 @@ async function getAuthenticatedActor(): Promise<
   { actor: AuthActor } | { response: Response }
 > {
   try {
-    const supabase = createServerClient();
+    const supabase = createClient();
     const { data: session, error } = await supabase.auth.getUser();
 
     if (error || !session?.user) {

--- a/src/modules/tasks/services/progress-service.ts
+++ b/src/modules/tasks/services/progress-service.ts
@@ -165,7 +165,7 @@ export class ProgressService {
       input.attachments ?? []
     );
 
-    const currentStatus = instance.task.status as TaskStatus;
+    const currentStatus = instance.status as TaskStatus;
     const nextStatus = resolveInstanceStatus(percentage, currentStatus);
     const completedAt =
       nextStatus === 'COMPLETED' ? new Date().toISOString() : null;


### PR DESCRIPTION
## Summary
- keep instance progress updates based on the instance status so overdue instances stay overdue until completion
- authenticate the task progress route with the cookie-aware Supabase client so signed-in users can submit updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6965a86d08320931d6269834b6be1